### PR TITLE
Dashboard: Wire up real stats, activity, and performance charts

### DIFF
--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -1,15 +1,26 @@
 import React, { useState, useEffect } from "react";
 import { useDarkModeContext } from "../DarkModeProvider";
 import { getDarkModeStyles } from "../getDarkModeStyles";
-import {
-  getActivitySummary,
-  getRecentGames,
-  formatDuration,
-  getGameDisplayName,
-  ActivitySummary,
-  GameSession,
-  GameType,
-} from "../../services/gameStatsService";
+import API_URL from "../../config/api";
+
+// Types
+interface GameStat {
+  game: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  total: number;
+}
+
+interface ActivityDay {
+  date: string;
+  count: number;
+}
+
+interface HistoryDay {
+  date: string;
+  win_rate: number;
+}
 
 // Styles
 const containerStyle: React.CSSProperties = {
@@ -34,7 +45,6 @@ const headingStyle: React.CSSProperties = {
   color: "#7ecbff",
   fontWeight: 800,
   letterSpacing: "0.01em",
-  textShadow: "0 2px 12px #23272f55",
   textAlign: "center",
 };
 
@@ -43,9 +53,6 @@ const sectionHeadingStyle: React.CSSProperties = {
   fontWeight: 700,
   color: "#23272f",
   marginBottom: "0.8em",
-  display: "flex",
-  alignItems: "center",
-  gap: "0.5em",
 };
 
 const statGridStyle: React.CSSProperties = {
@@ -92,26 +99,6 @@ const tdStyle: React.CSSProperties = {
   borderBottom: "1px solid #f0f4f8",
 };
 
-const resultBadgeStyle = (result: string): React.CSSProperties => {
-  const colors: Record<string, { bg: string; text: string }> = {
-    win: { bg: "#d4edda", text: "#155724" },
-    loss: { bg: "#f8d7da", text: "#721c24" },
-    draw: { bg: "#fff3cd", text: "#856404" },
-    abandoned: { bg: "#e2e3e5", text: "#383d41" },
-  };
-  const color = colors[result] || colors.abandoned;
-  return {
-    display: "inline-block",
-    padding: "0.25em 0.75em",
-    borderRadius: "12px",
-    fontSize: "0.85em",
-    fontWeight: 600,
-    backgroundColor: color.bg,
-    color: color.text,
-    textTransform: "capitalize",
-  };
-};
-
 const gameIconMap: Record<string, string> = {
   tictactoe: "⭕",
   connectfour: "🔴",
@@ -128,192 +115,180 @@ const gameIconMap: Record<string, string> = {
   rockpaperscissors: "✊",
 };
 
+function getAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem("access_token");
+  return token
+    ? { "Content-Type": "application/json", Authorization: `Bearer ${token}` }
+    : { "Content-Type": "application/json" };
+}
+
 const Dashboard: React.FC = () => {
-  const [summary, setSummary] = useState<ActivitySummary | null>(null);
-  const [recentGames, setRecentGames] = useState<GameSession[]>([]);
+  const [stats, setStats] = useState<GameStat[]>([]);
+  const [activity, setActivity] = useState<ActivityDay[]>([]);
+  const [history, setHistory] = useState<HistoryDay[]>([]);
   const [loading, setLoading] = useState(true);
-  const [days, setDays] = useState(7);
   const [darkMode] = useDarkModeContext();
 
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
-      const [summaryData, recentData] = await Promise.all([
-        getActivitySummary(days),
-        getRecentGames(15),
-      ]);
-      setSummary(summaryData);
-      setRecentGames(recentData);
+      const headers = getAuthHeaders();
+      try {
+        const [summaryRes, activityRes, historyRes] = await Promise.all([
+          fetch(`${API_URL}/api/stats/summary`, { headers }),
+          fetch(`${API_URL}/api/stats/activity`, { headers }),
+          fetch(`${API_URL}/api/stats/history`, { headers }),
+        ]);
+        const summaryData = summaryRes.ok ? await summaryRes.json() : { stats: [] };
+        const activityData = activityRes.ok ? await activityRes.json() : { activity: [] };
+        const historyData = historyRes.ok ? await historyRes.json() : { history: [] };
+        setStats(summaryData.stats || []);
+        setActivity(activityData.activity || []);
+        setHistory(historyData.history || []);
+      } catch (err) {
+        console.error("Failed to fetch dashboard data:", err);
+      }
       setLoading(false);
     };
     fetchData();
-  }, [days]);
+  }, []);
+
+  const totalGames = stats.reduce((s, g) => s + g.total, 0);
+  const totalWins = stats.reduce((s, g) => s + g.wins, 0);
+  const totalLosses = stats.reduce((s, g) => s + g.losses, 0);
+  const totalDraws = stats.reduce((s, g) => s + g.draws, 0);
+  const winRate = totalGames > 0 ? ((totalWins / totalGames) * 100).toFixed(1) : "0.0";
+
+  const dk = (light: React.CSSProperties, dark: React.CSSProperties) =>
+    getDarkModeStyles(darkMode, light, dark);
 
   if (loading) {
     return (
-      <div style={getDarkModeStyles(darkMode, containerStyle, { background: "#181a20", color: "#f5f6fa" })}>
-        <h1 style={getDarkModeStyles(darkMode, headingStyle, { color: "#7ecbff" })}>📊 Dashboard</h1>
-        <div style={{ ...cardStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}), textAlign: "center" }}>
-          <p style={{ fontSize: "1.2em", color: darkMode ? "#aaa" : "#666" }}>Loading your stats...</p>
+      <div style={dk(containerStyle, { ...containerStyle, background: "#181a20", color: "#f5f6fa" })}>
+        <h1 style={dk(headingStyle, { ...headingStyle, color: "#7ecbff" })}>📊 Dashboard</h1>
+        <div style={dk(cardStyle, { ...cardStyle, background: "#23272f", color: "#f5f6fa" })}>
+          <p style={{ textAlign: "center", color: darkMode ? "#aaa" : "#666", fontSize: "1.2em" }}>
+            Loading your stats...
+          </p>
         </div>
       </div>
     );
   }
 
-  const hasData = summary && summary.totalGames > 0;
+  const hasData = totalGames > 0;
 
   return (
-    <div style={getDarkModeStyles(darkMode, containerStyle, { background: "#181a20", color: "#f5f6fa" })}>
-      <h1 style={getDarkModeStyles(darkMode, headingStyle, { color: "#7ecbff" })}>📊 Dashboard</h1>
+    <div style={dk(containerStyle, { ...containerStyle, background: "#181a20", color: "#f5f6fa" })}>
+      <h1 style={dk(headingStyle, { ...headingStyle, color: "#7ecbff" })}>📊 Dashboard</h1>
       <p style={{ textAlign: "center", color: darkMode ? "#aaa" : "#666", marginBottom: "1.5em" }}>
         Track your gaming activity and statistics
       </p>
 
-      {/* Period Selector */}
-      <div style={{ textAlign: "center", marginBottom: "1.5em" }}>
-        <span style={{ marginRight: "1em", fontWeight: 500 }}>Show stats for:</span>
-        {[7, 14, 30].map((d) => (
-          <button
-            key={d}
-            onClick={() => setDays(d)}
-            style={{
-              padding: "0.5em 1em",
-              margin: "0 0.3em",
-              borderRadius: "8px",
-              border: days === d ? `2px solid ${darkMode ? "#7ecbff" : "#3a7bd5"}` : `1px solid ${darkMode ? "#444" : "#ddd"}`,
-              background: days === d ? (darkMode ? "#23272f" : "#e3f0ff") : (darkMode ? "#181a20" : "#fff"),
-              color: days === d ? (darkMode ? "#7ecbff" : "#3a7bd5") : (darkMode ? "#aaa" : "#666"),
-              fontWeight: days === d ? 600 : 400,
-              cursor: "pointer",
-            }}
-          >
-            {d} days
-          </button>
-        ))}
-      </div>
-
       {!hasData ? (
-        <div style={{ ...cardStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}), textAlign: "center" }}>
-          <h2 style={{ color: darkMode ? "#7ecbff" : "#3a7bd5", marginBottom: "0.5em" }}>🎮 No games recorded yet!</h2>
-          <p style={{ color: darkMode ? "#aaa" : "#666" }}>
+        <div style={dk(cardStyle, { ...cardStyle, background: "#23272f", color: "#f5f6fa" })}>
+          <h2 style={{ color: darkMode ? "#7ecbff" : "#3a7bd5", textAlign: "center" }}>
+            🎮 No games recorded yet!
+          </h2>
+          <p style={{ color: darkMode ? "#aaa" : "#666", textAlign: "center" }}>
             Start playing some games and your statistics will appear here.
           </p>
         </div>
       ) : (
         <>
-          {/* Summary Stats */}
-          <div style={{ ...cardStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}) }}>
-            <h2 style={{ ...sectionHeadingStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>📈 Overview (Last {days} Days)</h2>
+          {/* Overview */}
+          <div style={dk(cardStyle, { ...cardStyle, background: "#23272f", color: "#f5f6fa" })}>
+            <h2 style={dk(sectionHeadingStyle, { ...sectionHeadingStyle, color: "#7ecbff" })}>
+              📈 Overview
+            </h2>
             <div style={statGridStyle}>
-              <div style={{ ...statBoxStyle, ...(darkMode ? { background: "#181a20", color: "#7ecbff" } : {}) }}>
-                <div style={{ ...statValueStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>{summary!.totalGames}</div>
-                <div style={{ ...statLabelStyle, ...(darkMode ? { color: "#aaa" } : {}) }}>Games Played</div>
-              </div>
-              <div style={{ ...statBoxStyle, ...(darkMode ? { background: "#181a20", color: "#7ecbff" } : {}) }}>
-                <div style={{ ...statValueStyle, color: darkMode ? "#28e07b" : "#28a745" }}>{summary!.totalWins}</div>
-                <div style={{ ...statLabelStyle, ...(darkMode ? { color: "#aaa" } : {}) }}>Wins</div>
-              </div>
-              <div style={{ ...statBoxStyle, ...(darkMode ? { background: "#181a20", color: "#7ecbff" } : {}) }}>
-                <div style={{ ...statValueStyle, color: darkMode ? "#ff7e67" : "#dc3545" }}>{summary!.totalLosses}</div>
-                <div style={{ ...statLabelStyle, ...(darkMode ? { color: "#aaa" } : {}) }}>Losses</div>
-              </div>
-              <div style={{ ...statBoxStyle, ...(darkMode ? { background: "#181a20", color: "#7ecbff" } : {}) }}>
-                <div style={{ ...statValueStyle, color: darkMode ? "#ffe066" : "#ffc107" }}>{summary!.totalDraws}</div>
-                <div style={{ ...statLabelStyle, ...(darkMode ? { color: "#aaa" } : {}) }}>Draws</div>
-              </div>
-              <div style={{ ...statBoxStyle, ...(darkMode ? { background: "#181a20", color: "#7ecbff" } : {}) }}>
-                <div style={{ ...statValueStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>{summary!.winRate.toFixed(1)}%</div>
-                <div style={{ ...statLabelStyle, ...(darkMode ? { color: "#aaa" } : {}) }}>Win Rate</div>
-              </div>
-              <div style={{ ...statBoxStyle, ...(darkMode ? { background: "#181a20", color: "#7ecbff" } : {}) }}>
-                <div style={{ ...statValueStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>{formatDuration(summary!.totalTimeSeconds)}</div>
-                <div style={{ ...statLabelStyle, ...(darkMode ? { color: "#aaa" } : {}) }}>Time Played</div>
-              </div>
+              {[
+                { label: "Games Played", value: totalGames, color: darkMode ? "#7ecbff" : "#3a7bd5" },
+                { label: "Wins", value: totalWins, color: darkMode ? "#28e07b" : "#28a745" },
+                { label: "Losses", value: totalLosses, color: darkMode ? "#ff7e67" : "#dc3545" },
+                { label: "Draws", value: totalDraws, color: darkMode ? "#ffe066" : "#ffc107" },
+                { label: "Win Rate", value: `${winRate}%`, color: darkMode ? "#7ecbff" : "#3a7bd5" },
+              ].map(({ label, value, color }) => (
+                <div key={label} style={dk(statBoxStyle, { ...statBoxStyle, background: "#181a20" })}>
+                  <div style={{ ...statValueStyle, color }}>{value}</div>
+                  <div style={dk(statLabelStyle, { ...statLabelStyle, color: "#aaa" })}>{label}</div>
+                </div>
+              ))}
             </div>
           </div>
 
           {/* Per-Game Breakdown */}
-          {summary!.gameBreakdown.length > 0 && (
-            <div style={{ ...cardStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}) }}>
-              <h2 style={{ ...sectionHeadingStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>🎮 Game Breakdown</h2>
-              <div style={{ overflowX: "auto" }}>
-                <table style={{ ...tableStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}) }}>
-                  <thead>
-                    <tr>
-                      <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Game</th>
-                      <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Played</th>
-                      <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Wins</th>
-                      <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Losses</th>
-                      <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Draws</th>
-                      <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Win Rate</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {summary!.gameBreakdown.map((game) => {
-                      const winRate = game.totalGames > 0
-                        ? ((game.wins / game.totalGames) * 100).toFixed(1)
-                        : "0.0";
-                      return (
-                        <tr key={game.gameType}>
-                          <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                            <span style={{ marginRight: "0.5em" }}>
-                              {gameIconMap[game.gameType] || "🎮"}
-                            </span>
-                            {getGameDisplayName(game.gameType as GameType)}
-                          </td>
-                          <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>{game.totalGames}</td>
-                          <td style={{ ...tdStyle, color: darkMode ? "#28e07b" : "#28a745", fontWeight: 600, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                            {game.wins}
-                          </td>
-                          <td style={{ ...tdStyle, color: darkMode ? "#ff7e67" : "#dc3545", fontWeight: 600, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                            {game.losses}
-                          </td>
-                          <td style={{ ...tdStyle, color: darkMode ? "#ffe066" : "#ffc107", fontWeight: 600, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                            {game.draws}
-                          </td>
-                          <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>{winRate}%</td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
+          <div style={dk(cardStyle, { ...cardStyle, background: "#23272f", color: "#f5f6fa" })}>
+            <h2 style={dk(sectionHeadingStyle, { ...sectionHeadingStyle, color: "#7ecbff" })}>
+              🎮 Game Breakdown
+            </h2>
+            <div style={{ overflowX: "auto" }}>
+              <table style={tableStyle}>
+                <thead>
+                  <tr>
+                    {["Game", "Played", "Wins", "Losses", "Draws", "Win Rate"].map((h) => (
+                      <th key={h} style={dk(thStyle, { ...thStyle, color: "#aaa", borderBottom: "2px solid #444" })}>
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {stats.map((g) => {
+                    const wr = g.total > 0 ? ((g.wins / g.total) * 100).toFixed(1) : "0.0";
+                    return (
+                      <tr key={g.game}>
+                        <td style={dk(tdStyle, { ...tdStyle, borderBottom: "1px solid #444" })}>
+                          <span style={{ marginRight: "0.5em" }}>
+                            {gameIconMap[g.game.toLowerCase()] || "🎮"}
+                          </span>
+                          {g.game}
+                        </td>
+                        <td style={dk(tdStyle, { ...tdStyle, borderBottom: "1px solid #444" })}>{g.total}</td>
+                        <td style={{ ...dk(tdStyle, { ...tdStyle, borderBottom: "1px solid #444" }), color: darkMode ? "#28e07b" : "#28a745", fontWeight: 600 }}>
+                          {g.wins}
+                        </td>
+                        <td style={{ ...dk(tdStyle, { ...tdStyle, borderBottom: "1px solid #444" }), color: darkMode ? "#ff7e67" : "#dc3545", fontWeight: 600 }}>
+                          {g.losses}
+                        </td>
+                        <td style={{ ...dk(tdStyle, { ...tdStyle, borderBottom: "1px solid #444" }), color: darkMode ? "#ffe066" : "#ffc107", fontWeight: 600 }}>
+                          {g.draws}
+                        </td>
+                        <td style={dk(tdStyle, { ...tdStyle, borderBottom: "1px solid #444" })}>{wr}%</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
-          )}
+          </div>
 
-          {/* Daily Activity Chart */}
-          {summary!.dailyBreakdown.length > 0 && (
-            <div style={{ ...cardStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}) }}>
-              <h2 style={{ ...sectionHeadingStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>📅 Daily Activity</h2>
-              <div style={{ display: "flex", gap: "0.5em", alignItems: "flex-end", height: "120px" }}>
-                {[...summary!.dailyBreakdown].reverse().map((day, idx) => {
-                  const maxGames = Math.max(...summary!.dailyBreakdown.map((d) => d.totalGames), 1);
-                  const height = (day.totalGames / maxGames) * 100;
+          {/* Daily Activity */}
+          {activity.length > 0 && (
+            <div style={dk(cardStyle, { ...cardStyle, background: "#23272f", color: "#f5f6fa" })}>
+              <h2 style={dk(sectionHeadingStyle, { ...sectionHeadingStyle, color: "#7ecbff" })}>
+                📅 Daily Activity (Last 30 Days)
+              </h2>
+              <div style={{ display: "flex", gap: "0.4em", alignItems: "flex-end", height: "120px" }}>
+                {activity.map((day, idx) => {
+                  const maxCount = Math.max(...activity.map((d) => d.count), 1);
+                  const height = (day.count / maxCount) * 100;
                   return (
-                    <div
-                      key={idx}
-                      style={{
-                        flex: 1,
-                        display: "flex",
-                        flexDirection: "column",
-                        alignItems: "center",
-                      }}
-                    >
+                    <div key={idx} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center" }}>
                       <div
+                        title={`${day.date}: ${day.count} games`}
                         style={{
                           width: "100%",
                           maxWidth: "40px",
                           height: `${Math.max(height, 5)}%`,
-                          background: darkMode ? "linear-gradient(180deg, #7ecbff 0%, #3a7bd5 100%)" : "linear-gradient(180deg, #3a7bd5 0%, #7ecbff 100%)",
+                          background: darkMode
+                            ? "linear-gradient(180deg, #7ecbff 0%, #3a7bd5 100%)"
+                            : "linear-gradient(180deg, #3a7bd5 0%, #7ecbff 100%)",
                           borderRadius: "4px 4px 0 0",
                           minHeight: "4px",
                         }}
-                        title={`${day.totalGames} games`}
                       />
-                      <span style={{ fontSize: "0.7em", color: darkMode ? "#aaa" : "#999", marginTop: "0.3em" }}>
-                        {new Date(day.activityDate).toLocaleDateString(undefined, {
-                          weekday: "short",
-                        })}
+                      <span style={{ fontSize: "0.65em", color: darkMode ? "#aaa" : "#999", marginTop: "0.3em" }}>
+                        {new Date(day.date).toLocaleDateString(undefined, { weekday: "short" })}
                       </span>
                     </div>
                   );
@@ -321,50 +296,45 @@ const Dashboard: React.FC = () => {
               </div>
             </div>
           )}
+
+          {/* Win Rate Over Time */}
+          {history.length > 0 && (
+            <div style={dk(cardStyle, { ...cardStyle, background: "#23272f", color: "#f5f6fa" })}>
+              <h2 style={dk(sectionHeadingStyle, { ...sectionHeadingStyle, color: "#7ecbff" })}>
+                📈 Win Rate Over Time
+              </h2>
+              <div style={{ display: "flex", gap: "0.4em", alignItems: "flex-end", height: "120px" }}>
+                {history.map((day, idx) => {
+                  const height = day.win_rate;
+                  return (
+                    <div key={idx} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center" }}>
+                      <div
+                        title={`${day.date}: ${day.win_rate}% win rate`}
+                        style={{
+                          width: "100%",
+                          maxWidth: "40px",
+                          height: `${Math.max(height, 5)}%`,
+                          background: darkMode
+                            ? "linear-gradient(180deg, #28e07b 0%, #1a9950 100%)"
+                            : "linear-gradient(180deg, #28a745 0%, #28e07b 100%)",
+                          borderRadius: "4px 4px 0 0",
+                          minHeight: "4px",
+                        }}
+                      />
+                      <span style={{ fontSize: "0.65em", color: darkMode ? "#aaa" : "#999", marginTop: "0.3em" }}>
+                        {new Date(day.date).toLocaleDateString(undefined, { weekday: "short" })}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+              <div style={{ textAlign: "right", fontSize: "0.8em", color: darkMode ? "#aaa" : "#999", marginTop: "0.5em" }}>
+                Bar height = win rate %
+              </div>
+            </div>
+          )}
         </>
       )}
-
-      {/* Recent Games */}
-      <div style={{ ...cardStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}) }}>
-        <h2 style={{ ...sectionHeadingStyle, ...(darkMode ? { color: "#7ecbff" } : {}) }}>🕐 Recent Games</h2>
-        {recentGames.length === 0 ? (
-          <p style={{ color: darkMode ? "#aaa" : "#666", textAlign: "center" }}>No games played yet.</p>
-        ) : (
-          <div style={{ overflowX: "auto" }}>
-            <table style={{ ...tableStyle, ...(darkMode ? { background: "#23272f", color: "#f5f6fa" } : {}) }}>
-              <thead>
-                <tr>
-                  <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Game</th>
-                  <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Result</th>
-                  <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Moves</th>
-                  <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Duration</th>
-                  <th style={{ ...thStyle, ...(darkMode ? { color: "#aaa", borderBottom: "2px solid #444" } : {}) }}>Date</th>
-                </tr>
-              </thead>
-              <tbody>
-                {recentGames.map((game) => (
-                  <tr key={game.id}>
-                    <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                      <span style={{ marginRight: "0.5em" }}>
-                        {gameIconMap[game.gameType] || "🎮"}
-                      </span>
-                      {getGameDisplayName(game.gameType as GameType)}
-                    </td>
-                    <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                      <span style={resultBadgeStyle(game.result)}>{game.result}</span>
-                    </td>
-                    <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>{game.movesCount}</td>
-                    <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>{formatDuration(game.durationSeconds)}</td>
-                    <td style={{ ...tdStyle, ...(darkMode ? { borderBottom: "1px solid #444" } : {}) }}>
-                      {new Date(game.endedAt).toLocaleDateString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Rewrites the Dashboard to pull live data from the backend analytics 
API instead of calling non-existent service functions.

## Changes
- Replaced Dashboard.tsx to fetch from three real endpoints:
  - GET /api/stats/summary → Overview and Game Breakdown
  - GET /api/stats/activity → Daily Activity bar chart
  - GET /api/stats/history → Win Rate Over Time bar chart
- Uses JWT token from localStorage for authenticated requests
- Shows "No games recorded yet" state for new users
- Dark mode fully supported throughout

## Testing
Tested locally — Dashboard correctly shows 1 Wordle game played 
with daily activity and win rate charts rendering from real data.

## Issues Closed
Closes #79
Closes #80
Closes #81