### PR TITLE
Fix Comparison page: sync real win/loss/draw data from backend

### DIFF
--- a/frontend/src/components/pages/Comparison.tsx
+++ b/frontend/src/components/pages/Comparison.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
 import AIProgressChart from "./AIProgressChart";
-import gameStatsService from "../../services/gameStatsService";
 import { useDarkModeContext } from "../DarkModeProvider";
 import { getDarkModeStyles } from "../getDarkModeStyles";
-const { getGameDisplayName } = gameStatsService;
+import API_URL from "../../config/api";
 
 const baseContainerStyle: React.CSSProperties = {
   padding: "2.5em 2em",
@@ -24,45 +23,58 @@ const headingStyle: React.CSSProperties = {
   color: "#7ecbff",
   fontWeight: 800,
   letterSpacing: "0.01em",
-  textShadow: "0 2px 12px #23272f55"
+  textShadow: "0 2px 12px #23272f55",
 };
 
+interface GameStat {
+  game: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  total: number;
+}
+
 const Comparison: React.FC = () => {
-  const [gameBreakdown, setGameBreakdown] = useState<any[]>([]);
+  const [stats, setStats] = useState<GameStat[]>([]);
   const [loading, setLoading] = useState(true);
   const [darkMode] = useDarkModeContext();
-  const containerStyle = getDarkModeStyles(
-    darkMode,
-    baseContainerStyle,
-    {
-      background: "#23272f",
-      color: "#f5f6fa",
-      border: "1.5px solid #444",
-      boxShadow: "0 4px 32px 0 rgba(31, 38, 135, 0.37)",
-    }
-  );
+
+  const containerStyle = getDarkModeStyles(darkMode, baseContainerStyle, {
+    background: "#23272f",
+    color: "#f5f6fa",
+    border: "1.5px solid #444",
+    boxShadow: "0 4px 32px 0 rgba(31, 38, 135, 0.37)",
+  });
 
   useEffect(() => {
     async function fetchStats() {
       setLoading(true);
-      const summary = await gameStatsService.getActivitySummary(7);
-      setGameBreakdown(summary?.gameBreakdown || []);
+      try {
+        const token = localStorage.getItem("access_token");
+        const res = await fetch(`${API_URL}/api/stats/summary`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setStats(data.stats || []);
+        }
+      } catch (err) {
+        console.error("Failed to fetch stats:", err);
+      }
       setLoading(false);
     }
     fetchStats();
   }, []);
 
-  // Prepare chart data
-  const gameLabels = gameBreakdown.map(g => getGameDisplayName(g.gameType));
-  const userWins = gameBreakdown.map(g => g.wins);
-  const userLosses = gameBreakdown.map(g => g.losses);
-  const userDraws = gameBreakdown.map(g => g.draws);
-  // AI stats: AI wins = user losses, AI losses = user wins, AI draws = user draws
+  const gameLabels = stats.map((g) => g.game);
+  const userWins = stats.map((g) => g.wins);
+  const userLosses = stats.map((g) => g.losses);
+  const userDraws = stats.map((g) => g.draws);
+  // AI wins = user losses (and vice versa)
   const aiWins = userLosses;
   const aiLosses = userWins;
   const aiDraws = userDraws;
 
-  // Calculate totals for table
   const totalUserWins = userWins.reduce((a, b) => a + b, 0);
   const totalUserLosses = userLosses.reduce((a, b) => a + b, 0);
   const totalUserDraws = userDraws.reduce((a, b) => a + b, 0);
@@ -76,11 +88,13 @@ const Comparison: React.FC = () => {
       <p style={{ fontSize: "1.2em", marginBottom: "1.5em" }}>
         See how you stack up against the Grumpy AI:
       </p>
-      <table style={getDarkModeStyles(
-        darkMode,
-        { margin: "0 auto", background: "#181a20", borderRadius: 8, color: "#fff", minWidth: 320, fontSize: "1.05em" },
-        { background: "#181a20", color: "#7ecbff", border: "1px solid #444" }
-      )}>
+      <table
+        style={getDarkModeStyles(
+          darkMode,
+          { margin: "0 auto", background: "#181a20", borderRadius: 8, color: "#fff", minWidth: 320, fontSize: "1.05em" },
+          { background: "#181a20", color: "#7ecbff", border: "1px solid #444" }
+        )}
+      >
         <thead>
           <tr style={{ color: "#4f8cff" }}>
             <th style={{ padding: "0.5em 1em" }}>Player</th>
@@ -104,17 +118,16 @@ const Comparison: React.FC = () => {
           </tr>
         </tbody>
       </table>
-      <div style={getDarkModeStyles(
-        darkMode,
-        { color: "#aaa", marginTop: "1em" },
-        { color: "#b3e0ff" }
-      )}>
+      <div style={getDarkModeStyles(darkMode, { color: "#aaa", marginTop: "1em" }, { color: "#b3e0ff" })}>
         <i>Can you turn the tables and beat the AI?</i>
       </div>
-      {/* AI learning progress chart */}
       <div style={{ marginTop: "2.5em" }}>
         {loading ? (
           <div>Loading chart...</div>
+        ) : stats.length === 0 ? (
+          <div style={{ color: darkMode ? "#aaa" : "#666" }}>
+            Play some games to see your comparison chart!
+          </div>
         ) : (
           <AIProgressChart
             gameLabels={gameLabels}


### PR DESCRIPTION
## Summary
Fixes the Comparison page to pull live stats from the backend 
instead of calling a non-existent service function.

## Changes
- Replaced getActivitySummary call with direct fetch to 
  GET /api/stats/summary using JWT auth
- Table now shows real win/loss/draw totals for You vs Grumpy AI
- Chart now renders with real per-game breakdown data
- Shows friendly message if no games have been played yet

## Issues Closed
Closes #84
Closes #82