### PR TITLE
Backend: Record moves during game sessions (#93)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -10,6 +10,10 @@ except ImportError:
     from auth import auth_router, init_db
     from chatbot import chatbot_router
     from stats import stats_router
+try:
+    from .replays import replays_router
+except ImportError:
+    from replays import replays_router
 from fastapi.middleware.cors import CORSMiddleware
 import os
 
@@ -32,6 +36,7 @@ app.add_middleware(
 app.include_router(auth_router, prefix="/api")
 app.include_router(chatbot_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
+app.include_router(replays_router, prefix="/api")
 
 
 @app.on_event("startup")

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -46,6 +46,15 @@ def init_db():
             played_at TIMESTAMP DEFAULT NOW()
         )'''
     )
+    cursor.execute(
+        '''CREATE TABLE IF NOT EXISTS game_moves (
+            id SERIAL PRIMARY KEY,
+            session_id INTEGER NOT NULL REFERENCES game_results(id) ON DELETE CASCADE,
+            move_number INTEGER NOT NULL,
+            move_data JSONB NOT NULL,
+            played_at TIMESTAMP DEFAULT NOW()
+        )'''
+    )
     conn.commit()
     conn.close()
 

--- a/backend/replays.py
+++ b/backend/replays.py
@@ -1,0 +1,42 @@
+"""
+Replay API endpoints for recording and retrieving game moves.
+"""
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from typing import Any
+
+try:
+    from .auth import get_db
+    from .jwt_utils import verify_access_token
+except ImportError:
+    from auth import get_db
+    from jwt_utils import verify_access_token
+
+replays_router = APIRouter()
+
+
+class MoveRecord(BaseModel):
+    session_id: int
+    move_number: int
+    move_data: Any  # flexible JSON: board state, piece moved, guess, etc.
+
+
+@replays_router.post("/replays/moves")
+def record_move(
+    move: MoveRecord,
+    token_email: str = Depends(verify_access_token)
+):
+    """Record a single move for a game session."""
+    import json
+    conn = get_db()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO game_moves (session_id, move_number, move_data)
+        VALUES (%s, %s, %s)
+        """,
+        (move.session_id, move.move_number, json.dumps(move.move_data))
+    )
+    conn.commit()
+    conn.close()
+    return {"msg": "Move recorded"}

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -28,12 +28,13 @@ def record_result(
     conn = get_db()
     cursor = conn.cursor()
     cursor.execute(
-        "INSERT INTO game_results (email, game, outcome) VALUES (%s, %s, %s)",
+        "INSERT INTO game_results (email, game, outcome) VALUES (%s, %s, %s) RETURNING id",
         (token_email, result.game, result.outcome)
     )
+    session_id = cursor.fetchone()["id"]
     conn.commit()
     conn.close()
-    return {"msg": "Result recorded"}
+    return {"msg": "Result recorded", "session_id": session_id}
 
 
 @stats_router.get("/stats/summary")


### PR DESCRIPTION
## Summary
Adds the backend foundation for replay mode by creating a 
game_moves table and an endpoint to record individual moves 
during a game session.

## Changes
- Added game_moves table to init_db() in auth.py
  - Stores: session_id (FK to game_results), move_number, 
    move_data (JSONB), played_at timestamp
- Updated POST /api/stats/record to return session_id
  - Frontend can now capture the session_id after recording 
    a game result and use it to save moves
- Created backend/replays.py with:
  - POST /api/replays/moves — record a single move for a session
    - Accepts session_id, move_number, and flexible move_data JSON
- Registered replays_router in api.py

## Testing
Tested locally:
- Recorded a Wordle game and got back session_id: 3
- Recorded a move with guess and feedback data successfully

## Issues Closed
Closes #93