### PR TITLE
Loading skeletons on Dashboard and Human vs AI (#100)

### DIFF
--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  borderRadius?: string | number;
+  style?: React.CSSProperties;
+}
+
+const Skeleton: React.FC<SkeletonProps> = ({
+  width = "100%",
+  height = "1em",
+  borderRadius = 8,
+  style = {},
+}) => {
+  return (
+    <div
+      style={{
+        width,
+        height,
+        borderRadius,
+        background: "linear-gradient(90deg, rgba(126,203,255,0.06) 25%, rgba(126,203,255,0.12) 50%, rgba(126,203,255,0.06) 75%)",
+        backgroundSize: "200% 100%",
+        animation: "skeleton-pulse 1.5s ease-in-out infinite",
+        ...style,
+      }}
+    />
+  );
+};
+
+// Inject keyframe animation once
+if (typeof document !== "undefined") {
+  const styleId = "skeleton-keyframes";
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      @keyframes skeleton-pulse {
+        0% { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+}
+
+export default Skeleton;

--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDarkModeContext } from "../DarkModeProvider";
+import Skeleton from "../Skeleton";
 import API_URL from "../../config/api";
 
 interface GameStat { game: string; wins: number; losses: number; draws: number; total: number; }
@@ -70,6 +71,59 @@ const Dashboard: React.FC = () => {
     <h2 style={{ fontSize: "1.05em", fontWeight: 700, color: "#7ecbff", marginBottom: "1.2em" }}>{text}</h2>
   );
 
+  // Skeleton loading UI
+  const LoadingSkeleton = () => (
+    <>
+      {/* Overview skeleton */}
+      <div style={cardStyle}>
+        <Skeleton width="140px" height="1em" borderRadius={6} style={{ marginBottom: "1.2em" }} />
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: "1em" }}>
+          {[...Array(5)].map((_, i) => (
+            <div key={i} style={{
+              background: darkMode ? "rgba(255,255,255,0.04)" : "rgba(126,203,255,0.06)",
+              border: darkMode ? "1px solid rgba(126,203,255,0.08)" : "1px solid rgba(126,203,255,0.15)",
+              borderRadius: 12, padding: "1em", textAlign: "center" as const,
+            }}>
+              <Skeleton width="50%" height="2em" borderRadius={6} style={{ margin: "0 auto 0.5em" }} />
+              <Skeleton width="70%" height="0.8em" borderRadius={4} style={{ margin: "0 auto" }} />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Game breakdown skeleton */}
+      <div style={cardStyle}>
+        <Skeleton width="160px" height="1em" borderRadius={6} style={{ marginBottom: "1.5em" }} />
+        {[...Array(3)].map((_, i) => (
+          <div key={i} style={{ display: "flex", gap: "1em", marginBottom: "1em", alignItems: "center" }}>
+            <Skeleton width="30%" height="1em" borderRadius={4} />
+            <Skeleton width="10%" height="1em" borderRadius={4} />
+            <Skeleton width="10%" height="1em" borderRadius={4} />
+            <Skeleton width="10%" height="1em" borderRadius={4} />
+            <Skeleton width="10%" height="1em" borderRadius={4} />
+            <Skeleton width="15%" height="1em" borderRadius={4} />
+          </div>
+        ))}
+      </div>
+
+      {/* Chart skeleton */}
+      <div style={cardStyle}>
+        <Skeleton width="200px" height="1em" borderRadius={6} style={{ marginBottom: "1.5em" }} />
+        <div style={{ display: "flex", gap: "0.3em", alignItems: "flex-end", height: 120 }}>
+          {[...Array(15)].map((_, i) => (
+            <div key={i} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <Skeleton
+                width="100%"
+                height={`${20 + Math.random() * 60}%`}
+                borderRadius="4px 4px 0 0"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <div style={{ minHeight: "100vh", background: bg, fontFamily: "'DM Sans', 'Inter', sans-serif", transition: "background 0.3s" }}>
       <div style={{
@@ -83,7 +137,7 @@ const Dashboard: React.FC = () => {
 
       <div style={{ maxWidth: 1000, margin: "0 auto", padding: "48px 24px 64px" }}>
         {loading ? (
-          <div style={cardStyle}><p style={{ textAlign: "center", color: textMuted, fontSize: "1.1em" }}>Loading your stats...</p></div>
+          <LoadingSkeleton />
         ) : totalGames === 0 ? (
           <div style={cardStyle}>
             <div style={{ textAlign: "center", padding: "2em 0" }}>
@@ -125,7 +179,7 @@ const Dashboard: React.FC = () => {
                   <thead>
                     <tr>
                       {["Game", "Played", "Wins", "Losses", "Draws", "Win Rate"].map(h => (
-                        <th key={h} style={{ textAlign: "left", padding: "0.75em", borderBottom: `2px solid ${darkMode ? "rgba(126,203,255,0.1)" : "rgba(126,203,255,0.2)"}`, color: textMuted, fontWeight: 600, fontSize: "0.82em", textTransform: "uppercase" as const, letterSpacing: "0.04em" }}>{h}</th>
+                        <th key={h} style={{ textAlign: "left", padding: "0.75em", borderBottom: `2px solid ${darkMode ? "rgba(126,203,255,0.1)" : "rgba(126,203,255,0.2)"}`, color: textMuted, fontWeight: 600, fontSize: "0.82em", textTransform: "uppercase" as const }}>{h}</th>
                       ))}
                     </tr>
                   </thead>

--- a/frontend/src/components/pages/HumanVsAI.tsx
+++ b/frontend/src/components/pages/HumanVsAI.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import AICoach from "../AICoach";
+import Skeleton from "../Skeleton";
 import { useDarkModeContext } from "../DarkModeProvider";
 import API_URL from "../../config/api";
 
@@ -74,9 +75,24 @@ const HumanVsAI: React.FC = () => {
     <h2 style={{ fontSize: "1.05em", fontWeight: 700, color: "#7ecbff", marginBottom: "1.2em" }}>{text}</h2>
   );
 
+  // Skeleton for the record table
+  const RecordSkeleton = () => (
+    <div style={cardStyle}>
+      <Skeleton width="160px" height="1em" borderRadius={6} style={{ marginBottom: "1.5em" }} />
+      {[...Array(3)].map((_, i) => (
+        <div key={i} style={{ display: "flex", gap: "1em", marginBottom: "1em", alignItems: "center" }}>
+          <Skeleton width="35%" height="1em" borderRadius={4} />
+          <Skeleton width="10%" height="1em" borderRadius={4} />
+          <Skeleton width="10%" height="1em" borderRadius={4} />
+          <Skeleton width="10%" height="1em" borderRadius={4} />
+          <Skeleton width="10%" height="1em" borderRadius={4} />
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <div style={{ minHeight: "100vh", background: bg, fontFamily: "'DM Sans', 'Inter', sans-serif", transition: "background 0.3s" }}>
-      {/* Header */}
       <div style={{
         background: darkMode ? "linear-gradient(135deg, #0f1117 0%, #161b27 100%)" : "linear-gradient(135deg, #1a1a2e 0%, #0f3460 100%)",
         padding: "56px 24px 64px", textAlign: "center", position: "relative", overflow: "hidden",
@@ -168,64 +184,78 @@ const HumanVsAI: React.FC = () => {
           {selectedGame ? `▶ Start ${selectedGame}` : "Select a game to start"}
         </button>
 
-        {/* Your Record */}
-        <div style={cardStyle}>
-          {sectionTitle("📊 Your Record vs AI")}
-          {loading ? (
-            <p style={{ color: textMuted }}>Loading stats...</p>
-          ) : stats.length === 0 ? (
-            <p style={{ color: textMuted }}>Play some games to see your record!</p>
-          ) : (
+        {/* Your Record — skeleton while loading */}
+        {loading ? (
+          <RecordSkeleton />
+        ) : (
+          <div style={cardStyle}>
+            {sectionTitle("📊 Your Record vs AI")}
+            {stats.length === 0 ? (
+              <p style={{ color: textMuted }}>Play some games to see your record!</p>
+            ) : (
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.95em" }}>
+                <thead>
+                  <tr>
+                    {["Game", "Wins", "Losses", "Draws", "Total"].map(h => (
+                      <th key={h} style={{ textAlign: "left", padding: "0.75em", borderBottom: `2px solid ${darkMode ? "rgba(126,203,255,0.1)" : "rgba(126,203,255,0.2)"}`, color: textMuted, fontWeight: 600, fontSize: "0.82em", textTransform: "uppercase" as const }}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {stats.map(row => (
+                    <tr key={row.game} style={{ borderBottom: `1px solid ${darkMode ? "rgba(255,255,255,0.04)" : "rgba(126,203,255,0.08)"}` }}>
+                      <td style={{ padding: "0.85em 0.75em", color: textPrimary, fontWeight: 600 }}>{row.game}</td>
+                      <td style={{ padding: "0.85em 0.75em", color: "#28e07b", fontWeight: 600 }}>{row.wins}</td>
+                      <td style={{ padding: "0.85em 0.75em", color: "#ff7e67", fontWeight: 600 }}>{row.losses}</td>
+                      <td style={{ padding: "0.85em 0.75em", color: "#ffe066", fontWeight: 600 }}>{row.draws}</td>
+                      <td style={{ padding: "0.85em 0.75em", color: textMuted }}>{row.total}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
+
+        {/* Leaderboard — skeleton while loading */}
+        {loading ? (
+          <div style={cardStyle}>
+            <Skeleton width="120px" height="1em" borderRadius={6} style={{ marginBottom: "1.5em" }} />
+            {[...Array(2)].map((_, i) => (
+              <div key={i} style={{ display: "flex", gap: "1em", marginBottom: "1em" }}>
+                <Skeleton width="40%" height="1em" borderRadius={4} />
+                <Skeleton width="15%" height="1em" borderRadius={4} />
+                <Skeleton width="15%" height="1em" borderRadius={4} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={cardStyle}>
+            {sectionTitle("🏅 Leaderboard")}
             <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.95em" }}>
               <thead>
                 <tr>
-                  {["Game", "Wins", "Losses", "Draws", "Total"].map(h => (
+                  {["Player", "Wins", "Losses"].map(h => (
                     <th key={h} style={{ textAlign: "left", padding: "0.75em", borderBottom: `2px solid ${darkMode ? "rgba(126,203,255,0.1)" : "rgba(126,203,255,0.2)"}`, color: textMuted, fontWeight: 600, fontSize: "0.82em", textTransform: "uppercase" as const }}>{h}</th>
                   ))}
                 </tr>
               </thead>
               <tbody>
-                {stats.map(row => (
-                  <tr key={row.game} style={{ borderBottom: `1px solid ${darkMode ? "rgba(255,255,255,0.04)" : "rgba(126,203,255,0.08)"}` }}>
-                    <td style={{ padding: "0.85em 0.75em", color: textPrimary, fontWeight: 600 }}>{row.game}</td>
+                {[
+                  { player: "🧑 You", wins: totalWins, losses: totalLosses },
+                  { player: "🤖 Grumpy AI", wins: totalLosses, losses: totalWins },
+                ].map(row => (
+                  <tr key={row.player} style={{ borderBottom: `1px solid ${darkMode ? "rgba(255,255,255,0.04)" : "rgba(126,203,255,0.08)"}` }}>
+                    <td style={{ padding: "0.85em 0.75em", color: textPrimary, fontWeight: 600 }}>{row.player}</td>
                     <td style={{ padding: "0.85em 0.75em", color: "#28e07b", fontWeight: 600 }}>{row.wins}</td>
                     <td style={{ padding: "0.85em 0.75em", color: "#ff7e67", fontWeight: 600 }}>{row.losses}</td>
-                    <td style={{ padding: "0.85em 0.75em", color: "#ffe066", fontWeight: 600 }}>{row.draws}</td>
-                    <td style={{ padding: "0.85em 0.75em", color: textMuted }}>{row.total}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
-          )}
-        </div>
+          </div>
+        )}
 
-        {/* Leaderboard */}
-        <div style={cardStyle}>
-          {sectionTitle("🏅 Leaderboard")}
-          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.95em" }}>
-            <thead>
-              <tr>
-                {["Player", "Wins", "Losses"].map(h => (
-                  <th key={h} style={{ textAlign: "left", padding: "0.75em", borderBottom: `2px solid ${darkMode ? "rgba(126,203,255,0.1)" : "rgba(126,203,255,0.2)"}`, color: textMuted, fontWeight: 600, fontSize: "0.82em", textTransform: "uppercase" as const }}>{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {[
-                { player: "🧑 You", wins: totalWins, losses: totalLosses },
-                { player: "🤖 Grumpy AI", wins: totalLosses, losses: totalWins },
-              ].map(row => (
-                <tr key={row.player} style={{ borderBottom: `1px solid ${darkMode ? "rgba(255,255,255,0.04)" : "rgba(126,203,255,0.08)"}` }}>
-                  <td style={{ padding: "0.85em 0.75em", color: textPrimary, fontWeight: 600 }}>{row.player}</td>
-                  <td style={{ padding: "0.85em 0.75em", color: "#28e07b", fontWeight: 600 }}>{row.wins}</td>
-                  <td style={{ padding: "0.85em 0.75em", color: "#ff7e67", fontWeight: 600 }}>{row.losses}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        {/* AI Coach */}
         <AICoach />
       </div>
     </div>


### PR DESCRIPTION
## Summary
Replaces plain "Loading..." text with animated skeleton 
placeholder UI on Dashboard and Human vs AI pages.

## Changes
- Created Skeleton.tsx — reusable skeleton component
  - Accepts width, height, borderRadius props
  - Animated pulse effect using CSS keyframes
  - Injects keyframe styles once into the document head
- Updated Dashboard.tsx:
  - Overview stat boxes show 5 skeleton cards while loading
  - Game breakdown table shows 3 skeleton rows while loading
  - Activity chart shows 15 skeleton bars while loading
- Updated HumanVsAI.tsx:
  - Your Record table shows skeleton rows while loading
  - Leaderboard shows skeleton rows while loading
  - Game selection and controls render immediately (no loading)

## Testing
Tested locally — skeleton placeholders appear briefly on page 
load before real data appears. Data loads correctly after 
logging in with a fresh token.

## Issues Closed
Closes #100