### PR TITLE
Add empty state illustrations to Dashboard, Human vs AI, and Comparison (#101)

### DIFF
--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useDarkModeContext } from "./DarkModeProvider";
+
+interface EmptyStateProps {
+  icon?: string;
+  title: string;
+  description: string;
+  actionLabel?: string;
+  actionRoute?: string;
+  secondaryLabel?: string;
+  secondaryRoute?: string;
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({
+  icon = "🎮",
+  title,
+  description,
+  actionLabel,
+  actionRoute,
+  secondaryLabel,
+  secondaryRoute,
+}) => {
+  const navigate = useNavigate();
+  const [darkMode] = useDarkModeContext();
+
+  const textPrimary = darkMode ? "#f0f4ff" : "#1a1a2e";
+  const textMuted = darkMode ? "rgba(255,255,255,0.5)" : "rgba(26,26,46,0.55)";
+  const cardBg = darkMode ? "rgba(255,255,255,0.04)" : "rgba(255,255,255,0.95)";
+  const cardBorder = darkMode ? "1px solid rgba(126,203,255,0.1)" : "1px solid rgba(126,203,255,0.2)";
+
+  return (
+    <div style={{
+      background: cardBg, border: cardBorder, borderRadius: 20,
+      padding: "3.5em 2em", textAlign: "center",
+      backdropFilter: "blur(8px)",
+      boxShadow: darkMode ? "0 2px 8px rgba(0,0,0,0.2)" : "0 2px 8px rgba(80,120,200,0.06)",
+    }}>
+      {/* Illustrated icon with glow */}
+      <div style={{ position: "relative", display: "inline-block", marginBottom: "1.5em" }}>
+        <div style={{
+          position: "absolute", top: "50%", left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 100, height: 100, borderRadius: "50%",
+          background: "radial-gradient(circle, rgba(126,203,255,0.15) 0%, transparent 70%)",
+          pointerEvents: "none",
+        }} />
+        <div style={{
+          width: 80, height: 80, borderRadius: "50%",
+          background: darkMode ? "rgba(126,203,255,0.08)" : "rgba(126,203,255,0.12)",
+          border: "1px solid rgba(126,203,255,0.2)",
+          display: "flex", alignItems: "center", justifyContent: "center",
+          fontSize: "2.2em",
+          position: "relative",
+        }}>
+          {icon}
+        </div>
+      </div>
+
+      {/* Text */}
+      <h2 style={{
+        fontSize: "1.3em", fontWeight: 700,
+        color: textPrimary, marginBottom: "0.5em",
+        letterSpacing: "-0.01em",
+      }}>
+        {title}
+      </h2>
+      <p style={{
+        color: textMuted, fontSize: "0.95em",
+        lineHeight: 1.7, maxWidth: 340,
+        margin: "0 auto 2em",
+      }}>
+        {description}
+      </p>
+
+      {/* Actions */}
+      <div style={{ display: "flex", gap: "0.8em", justifyContent: "center", flexWrap: "wrap" }}>
+        {actionLabel && actionRoute && (
+          <button
+            onClick={() => navigate(actionRoute)}
+            style={{
+              padding: "0.75em 1.8em", borderRadius: 50, border: "none",
+              background: "linear-gradient(90deg, #7ecbff, #4fa3d1)",
+              color: "#1a1a2e", fontWeight: 700, fontSize: "0.95em",
+              cursor: "pointer", fontFamily: "inherit", transition: "all 0.2s",
+            }}
+          >
+            {actionLabel}
+          </button>
+        )}
+        {secondaryLabel && secondaryRoute && (
+          <button
+            onClick={() => navigate(secondaryRoute)}
+            style={{
+              padding: "0.75em 1.8em", borderRadius: 50,
+              border: darkMode ? "1px solid rgba(126,203,255,0.2)" : "1px solid rgba(126,203,255,0.3)",
+              background: "transparent",
+              color: darkMode ? "#7ecbff" : "#4fa3d1",
+              fontWeight: 600, fontSize: "0.95em",
+              cursor: "pointer", fontFamily: "inherit",
+            }}
+          >
+            {secondaryLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/frontend/src/components/pages/Comparison.tsx
+++ b/frontend/src/components/pages/Comparison.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import AIProgressChart from "./AIProgressChart";
 import { useDarkModeContext } from "../DarkModeProvider";
 import API_URL from "../../config/api";
+import EmptyState from "../EmptyState";
 
 interface GameStat {
   game: string;
@@ -155,10 +156,15 @@ const Comparison: React.FC = () => {
             )}
 
             {stats.length === 0 && (
-              <div style={{ ...cardStyle, textAlign: "center", padding: "3em" }}>
-                <div style={{ fontSize: "2.5em", marginBottom: "0.5em" }}>🎮</div>
-                <p style={{ color: textMuted }}>Play some games to see your comparison!</p>
-              </div>
+              <EmptyState
+                icon="🆚"
+                title="Nothing to compare yet!"
+                description="Play some games against the AI and see how your record stacks up head to head."
+                actionLabel="Start Playing"
+                actionRoute="/games"
+                secondaryLabel="Human vs AI"
+                 secondaryRoute="/human-vs-ai"
+                />
             )}
           </>
         )}

--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useDarkModeContext } from "../DarkModeProvider";
 import Skeleton from "../Skeleton";
 import API_URL from "../../config/api";
+import EmptyState from "../EmptyState";
 
 interface GameStat { game: string; wins: number; losses: number; draws: number; total: number; }
 interface ActivityDay { date: string; count: number; }
@@ -139,13 +140,15 @@ const Dashboard: React.FC = () => {
         {loading ? (
           <LoadingSkeleton />
         ) : totalGames === 0 ? (
-          <div style={cardStyle}>
-            <div style={{ textAlign: "center", padding: "2em 0" }}>
-              <div style={{ fontSize: "3em", marginBottom: "0.5em" }}>🎮</div>
-              <h2 style={{ color: "#7ecbff", marginBottom: "0.5em" }}>No games recorded yet!</h2>
-              <p style={{ color: textMuted }}>Start playing some games and your stats will appear here.</p>
-            </div>
-          </div>
+          <EmptyState
+              icon="🎮"
+              title="No games recorded yet!"
+              description="Start playing some games and your stats will appear here. Every game you play gets tracked automatically."
+              actionLabel="Browse Games"
+              actionRoute="/games"
+              secondaryLabel="Challenge AI"
+              secondaryRoute="/human-vs-ai"
+          />
         ) : (
           <>
             {/* Overview */}

--- a/frontend/src/components/pages/HumanVsAI.tsx
+++ b/frontend/src/components/pages/HumanVsAI.tsx
@@ -4,6 +4,7 @@ import AICoach from "../AICoach";
 import Skeleton from "../Skeleton";
 import { useDarkModeContext } from "../DarkModeProvider";
 import API_URL from "../../config/api";
+import EmptyState from "../EmptyState";
 
 interface GameStat {
   game: string;
@@ -191,7 +192,13 @@ const HumanVsAI: React.FC = () => {
           <div style={cardStyle}>
             {sectionTitle("📊 Your Record vs AI")}
             {stats.length === 0 ? (
-              <p style={{ color: textMuted }}>Play some games to see your record!</p>
+              <EmptyState
+                icon="🏆"
+                title="No record yet!"
+                description="Play some games against the AI and your wins, losses, and draws will appear here."
+                actionLabel="Pick a Game Above"
+                actionRoute="/human-vs-ai"
+              />
             ) : (
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.95em" }}>
                 <thead>


### PR DESCRIPTION
## Summary
Replaces plain text empty states with friendly illustrated 
empty state components that encourage users to start playing.

## Changes
- Created EmptyState.tsx — reusable empty state component
  - Icon with circular glow background
  - Title, description, and up to two action buttons
  - Full dark mode support
- Updated Dashboard.tsx:
  - Replaced plain "No games recorded yet!" card with 
    EmptyState showing Browse Games and Challenge AI buttons
- Updated HumanVsAI.tsx:
  - Replaced plain text in Your Record table with EmptyState 
    showing Pick a Game button
- Updated Comparison.tsx:
  - Replaced plain text with EmptyState showing Start Playing 
    and Human vs AI buttons

## Testing
Tested locally — logged in with a new account with no game 
history, all three pages show the illustrated empty state 
with working navigation buttons.

## Issues Closed
Closes #101