### PR TITLE
Token expiry handling: redirect to login when JWT expires (#115)

### DIFF
--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useState, useEffect } from "react";
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -10,13 +10,22 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
-  () => !!localStorage.getItem("access_token")
-);
+    () => !!localStorage.getItem("access_token")
+  );
+  const [sessionExpired, setSessionExpired] = useState(false);
 
+  useEffect(() => {
+    if (localStorage.getItem("session_expired")) {
+      setSessionExpired(true);
+      localStorage.removeItem("session_expired");
+      setTimeout(() => setSessionExpired(false), 4000);
+    }
+  }, []);
 
   const login = (token: string) => {
     localStorage.setItem("access_token", token);
     setIsAuthenticated(true);
+    setSessionExpired(false);
   };
 
   const logout = () => {
@@ -26,6 +35,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   return (
     <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {sessionExpired && (
+        <div style={{
+          position: "fixed", top: 80, left: "50%", transform: "translateX(-50%)",
+          zIndex: 9999,
+          background: "rgba(255,126,103,0.12)",
+          border: "1px solid rgba(255,126,103,0.3)",
+          borderRadius: 12,
+          padding: "0.8em 1.6em",
+          color: "#ff7e67",
+          fontWeight: 600,
+          fontSize: "0.95em",
+          fontFamily: "'DM Sans', 'Inter', sans-serif",
+          backdropFilter: "blur(12px)",
+          boxShadow: "0 4px 24px rgba(0,0,0,0.3)",
+          animation: "fadeIn 0.3s ease",
+        }}>
+          ⚠️ Session expired — please log in again
+        </div>
+      )}
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/components/pages/Comparison.tsx
+++ b/frontend/src/components/pages/Comparison.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import AIProgressChart from "./AIProgressChart";
 import { useDarkModeContext } from "../DarkModeProvider";
-import API_URL from "../../config/api";
+import { apiFetch } from "../../config/apiFetch";
 import EmptyState from "../EmptyState";
 
 interface GameStat {
@@ -27,10 +27,7 @@ const Comparison: React.FC = () => {
     async function fetchStats() {
       setLoading(true);
       try {
-        const token = localStorage.getItem("access_token");
-        const res = await fetch(`${API_URL}/api/stats/summary`, {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-        });
+        const res = await apiFetch("/api/stats/summary");
         if (res.ok) {
           const data = await res.json();
           setStats(data.stats || []);

--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useDarkModeContext } from "../DarkModeProvider";
 import Skeleton from "../Skeleton";
-import API_URL from "../../config/api";
+import { apiFetch } from "../../config/apiFetch";
 import EmptyState from "../EmptyState";
 
 interface GameStat { game: string; wins: number; losses: number; draws: number; total: number; }
@@ -14,10 +14,6 @@ const gameIconMap: Record<string, string> = {
   snake: "🐍", memory: "🧠", hangman: "👔", sudoku: "🔲", rockpaperscissors: "✊",
 };
 
-function getAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem("access_token");
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 const Dashboard: React.FC = () => {
   const [stats, setStats] = useState<GameStat[]>([]);
@@ -35,12 +31,11 @@ const Dashboard: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
-      const headers = getAuthHeaders();
       try {
         const [summaryRes, activityRes, historyRes] = await Promise.all([
-          fetch(`${API_URL}/api/stats/summary`, { headers }),
-          fetch(`${API_URL}/api/stats/activity`, { headers }),
-          fetch(`${API_URL}/api/stats/history`, { headers }),
+          apiFetch("/api/stats/summary"),
+          apiFetch("/api/stats/activity"),
+          apiFetch("/api/stats/history"),
         ]);
         const summaryData = summaryRes.ok ? await summaryRes.json() : { stats: [] };
         const activityData = activityRes.ok ? await activityRes.json() : { activity: [] };

--- a/frontend/src/components/pages/HumanVsAI.tsx
+++ b/frontend/src/components/pages/HumanVsAI.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import AICoach from "../AICoach";
 import Skeleton from "../Skeleton";
 import { useDarkModeContext } from "../DarkModeProvider";
-import API_URL from "../../config/api";
+import { apiFetch } from "../../config/apiFetch";
 import EmptyState from "../EmptyState";
 
 interface GameStat {
@@ -14,10 +14,6 @@ interface GameStat {
   total: number;
 }
 
-function getAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem("access_token");
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 const HumanVsAI: React.FC = () => {
   const games = [
@@ -44,7 +40,7 @@ const HumanVsAI: React.FC = () => {
     async function fetchStats() {
       setLoading(true);
       try {
-        const res = await fetch(`${API_URL}/api/stats/summary`, { headers: getAuthHeaders() });
+        const res = await apiFetch("/api/stats/summary");
         if (res.ok && mounted) {
           const data = await res.json();
           setStats(data.stats || []);

--- a/frontend/src/components/pages/ProfilePage.tsx
+++ b/frontend/src/components/pages/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useDarkModeContext } from "../DarkModeProvider";
-import API_URL from "../../config/api";
+import { apiFetch } from "../../config/apiFetch";
 
 interface GameStat {
   game: string;
@@ -10,12 +10,6 @@ interface GameStat {
   total: number;
 }
 
-function getAuthHeaders(contentType = false): Record<string, string> {
-  const token = localStorage.getItem("access_token");
-  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
-  if (contentType) headers["Content-Type"] = "application/json";
-  return headers;
-}
 
 const ProfilePage: React.FC = () => {
   const [darkMode] = useDarkModeContext();
@@ -52,8 +46,8 @@ const ProfilePage: React.FC = () => {
       setLoadingInfo(true);
       try {
         const [infoRes, statsRes] = await Promise.all([
-          fetch(`${API_URL}/api/user/info`, { headers: getAuthHeaders() }),
-          fetch(`${API_URL}/api/stats/summary`, { headers: getAuthHeaders() }),
+          apiFetch("/api/user/info"),
+          apiFetch("/api/stats/summary"),
         ]);
         if (infoRes.ok) {
           const user = await infoRes.json();
@@ -79,9 +73,8 @@ const ProfilePage: React.FC = () => {
     setSavingInfo(true);
     setInfoMsg("");
     try {
-      const res = await fetch(`${API_URL}/api/user/update`, {
+      const res = await fetch("/api/user/update", {
         method: "PUT",
-        headers: getAuthHeaders(true),
         body: JSON.stringify({ new_username: newUsername, new_email: newEmail }),
       });
       if (res.ok) {
@@ -116,9 +109,8 @@ const ProfilePage: React.FC = () => {
     }
     setSavingPw(true);
     try {
-      const res = await fetch(`${API_URL}/api/user/update`, {
+      const res = await apiFetch("/api/user/update", {
         method: "PUT",
-        headers: getAuthHeaders(true),
         body: JSON.stringify({ new_password: newPassword }),
       });
       if (res.ok) {

--- a/frontend/src/components/pages/ReplayHistory.tsx
+++ b/frontend/src/components/pages/ReplayHistory.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDarkModeContext } from "../DarkModeProvider";
-import API_URL from "../../config/api";
+import { apiFetch } from "../../config/apiFetch";
 
 interface Replay {
   session_id: number;
@@ -11,10 +11,6 @@ interface Replay {
   move_count: number;
 }
 
-function getAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem("access_token");
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
 
 const outcomeColor = (outcome: string, darkMode: boolean) => {
   if (outcome === "win") return darkMode ? "#28e07b" : "#16a34a";
@@ -44,9 +40,7 @@ const ReplayHistory: React.FC = () => {
     async function fetchReplays() {
       setLoading(true);
       try {
-        const res = await fetch(`${API_URL}/api/replays`, {
-          headers: getAuthHeaders(),
-        });
+        const res = await apiFetch(`/api/replays`);
         if (res.ok) {
           const data = await res.json();
           setReplays(data.replays || []);

--- a/frontend/src/config/apiFetch.ts
+++ b/frontend/src/config/apiFetch.ts
@@ -1,0 +1,44 @@
+/**
+ * Global API fetch wrapper.
+ * Automatically adds Authorization header from localStorage.
+ * On 401, clears token and redirects to /login with session expired message.
+ */
+
+import API_URL from "./api";
+
+export function getAuthHeaders(contentType = false): Record<string, string> {
+  const token = localStorage.getItem("access_token");
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  if (contentType) headers["Content-Type"] = "application/json";
+  return headers;
+}
+
+export async function apiFetch(
+  path: string,
+  options: RequestInit = {}
+): Promise<Response> {
+  const token = localStorage.getItem("access_token");
+
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string> || {}),
+  };
+
+  if (token && !headers["Authorization"]) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_URL}${path}`, {
+    ...options,
+    headers,
+  });
+
+  if (res.status === 401) {
+    // Token expired or invalid — clear and redirect
+    localStorage.removeItem("access_token");
+    localStorage.setItem("session_expired", "1");
+    window.location.href = "/login";
+  }
+
+  return res;
+}


### PR DESCRIPTION
## Summary
When a JWT token expires, API calls now detect the 401 response 
and automatically redirect the user to /login with a session 
expired message instead of silently failing.

## Changes
- Created frontend/src/config/apiFetch.ts
  - Global fetch wrapper that automatically adds Authorization header
  - On 401 response: clears token, sets session_expired flag 
    in localStorage, redirects to /login
- Updated AuthProvider.tsx
  - Reads session_expired flag on mount and shows a red toast banner
  - Banner auto-dismisses after 4 seconds
  - Cleared on next successful login
- Migrated these pages from raw fetch to apiFetch:
  - Dashboard.tsx
  - HumanVsAI.tsx
  - Comparison.tsx
  - ProfilePage.tsx
  - ReplayHistory.tsx

## Testing
Tested locally — deleted access_token from localStorage, 
refreshed Dashboard, was immediately redirected to /login 
with "⚠️ Session expired — please log in again" banner.

## Issues Closed
Closes #115