### PR TITLE
Game result toast notification after each game ends (#116)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import ReplayHistory from "./components/pages/ReplayHistory";
 import ReplayViewer from "./components/pages/ReplayViewer";
 import SpectatorViewer from "./components/pages/SpectatorViewer";
 import ProfilePage from "./components/pages/ProfilePage";
+import { ToastProvider } from "./components/ToastProvider";
 
 
 // Protect all routes except public pages
@@ -60,6 +61,7 @@ const PublicLandingRoute = () => {
 function App() {
   return (
     <AuthProvider>
+      <ToastProvider>
       <Router>
         <Navbar />
         <Routes>
@@ -109,6 +111,7 @@ function App() {
         </Routes>
         <Chatbot />
       </Router>
+      </ToastProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -1,0 +1,123 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
+
+interface Toast {
+  id: number;
+  message: string;
+  type: "success" | "loss" | "draw" | "info";
+}
+
+interface ToastContextType {
+  showToast: (message: string, type?: Toast["type"]) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+};
+
+const toastColors: Record<Toast["type"], { bg: string; border: string; color: string; icon: string }> = {
+  success: {
+    bg: "rgba(40,224,123,0.12)",
+    border: "rgba(40,224,123,0.3)",
+    color: "#28e07b",
+    icon: "✅",
+  },
+  loss: {
+    bg: "rgba(255,126,103,0.12)",
+    border: "rgba(255,126,103,0.3)",
+    color: "#ff7e67",
+    icon: "📊",
+  },
+  draw: {
+    bg: "rgba(255,224,102,0.12)",
+    border: "rgba(255,224,102,0.3)",
+    color: "#ffe066",
+    icon: "🤝",
+  },
+  info: {
+    bg: "rgba(126,203,255,0.12)",
+    border: "rgba(126,203,255,0.3)",
+    color: "#7ecbff",
+    icon: "ℹ️",
+  },
+};
+
+let toastId = 0;
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((message: string, type: Toast["type"] = "info") => {
+    const id = ++toastId;
+    setToasts(prev => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts(prev => prev.filter(t => t.id !== id));
+    }, 3000);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { outcome, label } = (e as CustomEvent).detail;
+      const type = outcome === "win" ? "success" : outcome === "loss" ? "loss" : "draw";
+      showToast(label, type);
+    };
+
+    window.addEventListener("game-recorded", handler);
+    return () => window.removeEventListener("game-recorded", handler);
+  }, [showToast]);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {/* Toast container */}
+      <div style={{
+        position: "fixed",
+        bottom: 32,
+        right: 24,
+        zIndex: 9999,
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.6em",
+        pointerEvents: "none",
+      }}>
+        {toasts.map(toast => {
+          const colors = toastColors[toast.type];
+          return (
+            <div
+              key={toast.id}
+              style={{
+                background: colors.bg,
+                border: `1px solid ${colors.border}`,
+                borderRadius: 12,
+                padding: "0.8em 1.4em",
+                color: colors.color,
+                fontWeight: 600,
+                fontSize: "0.95em",
+                fontFamily: "'DM Sans', 'Inter', sans-serif",
+                backdropFilter: "blur(12px)",
+                boxShadow: "0 4px 24px rgba(0,0,0,0.3)",
+                display: "flex",
+                alignItems: "center",
+                gap: "0.5em",
+                animation: "toast-slide-in 0.3s ease",
+                minWidth: 220,
+              }}
+            >
+              <span>{colors.icon}</span>
+              <span>{toast.message}</span>
+            </div>
+          );
+        })}
+      </div>
+      <style>{`
+        @keyframes toast-slide-in {
+          from { opacity: 0; transform: translateY(16px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </ToastContext.Provider>
+  );
+};

--- a/frontend/src/services/gameStatsService.ts
+++ b/frontend/src/services/gameStatsService.ts
@@ -209,6 +209,10 @@ export async function recordGame(params: RecordGameParams): Promise<{ success: b
       return { success: false };
     }
 
+    // Dispatch toast event for the UI to pick up
+    const outcome = params.result;
+    const label = outcome === 'win' ? 'Win recorded! 🏆' : outcome === 'loss' ? 'Loss recorded' : 'Draw recorded';
+    window.dispatchEvent(new CustomEvent('game-recorded', { detail: { outcome, label } }));
     return { success: true };
   } catch (error) {
     console.error('Error recording game:', error);


### PR DESCRIPTION
## Summary
Adds a toast notification that appears in the bottom right 
corner after a game result is recorded, confirming to the 
user that their result was saved.

## Changes
- Created ToastProvider.tsx
  - Global toast context with showToast(message, type) function
  - Types: success (green), loss (red), draw (yellow), info (blue)
  - Auto-dismisses after 3 seconds
  - Slide-in animation from bottom
  - Supports multiple toasts stacked
- Updated gameStatsService.ts
  - After successful record, dispatches a game-recorded 
    custom DOM event with outcome and label
- Updated ToastProvider to listen for game-recorded events
  - Win → "✅ Win recorded! 🏆" (green)
  - Loss → "📊 Loss recorded" (red)
  - Draw → "🤝 Draw recorded" (yellow)
- Wrapped App in ToastProvider

## Testing
Tested locally — played Wordle to completion, green toast 
appeared in bottom right and auto-dismissed after 3 seconds.

## Issues Closed
Closes #116