### PR TITLE
Smooth page transitions between routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import ReplayViewer from "./components/pages/ReplayViewer";
 import SpectatorViewer from "./components/pages/SpectatorViewer";
 import ProfilePage from "./components/pages/ProfilePage";
 import { ToastProvider } from "./components/ToastProvider";
+import PageWrapper from "./components/PageWrapper";
 
 
 // Protect all routes except public pages
@@ -64,51 +65,53 @@ function App() {
       <ToastProvider>
       <Router>
         <Navbar />
-        <Routes>
-          {/* Public routes - accessible to everyone */}
-          <Route path="/" element={<PublicLandingRoute />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/contact" element={<ContactPage />} />
-          <Route path="/faq" element={<FAQPage />} />
-          
-          {/* Protected routes - require authentication */}
-          <Route
-            path="/*"
-            element={
-              <ProtectedRoute>
-                <Routes>
-                  <Route path="home" element={<Home />} />
-                  <Route path="games" element={<GameSelection />} />
-                  <Route path="play/:game" element={<GamePlay />} />
-                  <Route path="play" element={<Navigate to="games" replace />} />
-                  <Route path="dashboard" element={<Dashboard />} />
-                  <Route path="comparison" element={<Comparison />} />
-                  <Route path="human-vs-ai" element={<HumanVsAI />} />
-                  <Route path="about" element={<About />} />
-                  <Route path="settings" element={<Settings />} />
-                  <Route path="play/wordle" element={<WordleGame />} />
-                  <Route path="play/sudoku" element={<SudokuGame />} />
-                  <Route path="play/tictactoe" element={<TicTacToeGame />} />
-                  <Route path="play/connectfour" element={<ConnectFourGame />} />
-                  <Route path="play/checkers" element={<CheckersGame />} />
-                  <Route path="play/chess" element={<ChessGame />} />
-                  <Route path="play/rps" element={<RockPaperScissorsGame />} />
-                  <Route path="play/minesweeper" element={<MinesweeperGame />} />
-                  <Route path="play/2048" element={<Game2048 />} />
-                  <Route path="play/hangman" element={<HangmanGame />} />
-                  <Route path="play/othello" element={<OthelloGame />} />
-                  <Route path="play/memory" element={<MemoryGame />} />
-                  <Route path="play/coming-soon" element={<ComingSoonGame name="Coming Soon" />} />
-                  <Route path="replays" element={<ReplayHistory />} />
-                  <Route path="replay/:session_id" element={<ReplayViewer />} />
-                  <Route path="/watch/:session_id" element={<SpectatorViewer />} />
-                  <Route path="profile" element={<ProfilePage />} />
-                </Routes>
-              </ProtectedRoute>
-            }
-          />
-        </Routes>
+        <PageWrapper>
+          <Routes>
+            {/* Public routes - accessible to everyone */}
+            <Route path="/" element={<PublicLandingRoute />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/contact" element={<ContactPage />} />
+            <Route path="/faq" element={<FAQPage />} />
+
+            {/* Protected routes - require authentication */}
+            <Route
+              path="/*"
+              element={
+                <ProtectedRoute>
+                  <Routes>
+                    <Route path="home" element={<Home />} />
+                    <Route path="games" element={<GameSelection />} />
+                    <Route path="play/:game" element={<GamePlay />} />
+                    <Route path="play" element={<Navigate to="games" replace />} />
+                    <Route path="dashboard" element={<Dashboard />} />
+                    <Route path="comparison" element={<Comparison />} />
+                    <Route path="human-vs-ai" element={<HumanVsAI />} />
+                    <Route path="about" element={<About />} />
+                    <Route path="settings" element={<Settings />} />
+                    <Route path="play/wordle" element={<WordleGame />} />
+                    <Route path="play/sudoku" element={<SudokuGame />} />
+                    <Route path="play/tictactoe" element={<TicTacToeGame />} />
+                    <Route path="play/connectfour" element={<ConnectFourGame />} />
+                    <Route path="play/checkers" element={<CheckersGame />} />
+                    <Route path="play/chess" element={<ChessGame />} />
+                    <Route path="play/rps" element={<RockPaperScissorsGame />} />
+                    <Route path="play/minesweeper" element={<MinesweeperGame />} />
+                    <Route path="play/2048" element={<Game2048 />} />
+                    <Route path="play/hangman" element={<HangmanGame />} />
+                    <Route path="play/othello" element={<OthelloGame />} />
+                    <Route path="play/memory" element={<MemoryGame />} />
+                    <Route path="play/coming-soon" element={<ComingSoonGame name="Coming Soon" />} />
+                    <Route path="replays" element={<ReplayHistory />} />
+                    <Route path="replay/:session_id" element={<ReplayViewer />} />
+                    <Route path="/watch/:session_id" element={<SpectatorViewer />} />
+                    <Route path="profile" element={<ProfilePage />} />
+                  </Routes>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </PageWrapper>
         <Chatbot />
       </Router>
       </ToastProvider>

--- a/frontend/src/components/PageWrapper.tsx
+++ b/frontend/src/components/PageWrapper.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+
+const PageWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const location = useLocation();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(false);
+    const timer = setTimeout(() => setVisible(true), 20);
+    return () => clearTimeout(timer);
+  }, [location.pathname]);
+
+  return (
+    <div
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(8px)",
+        transition: "opacity 0.25s ease, transform 0.25s ease",
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default PageWrapper;


### PR DESCRIPTION
## Summary
Adds a subtle fade-in and slide-up animation when navigating 
between pages, making the app feel more polished.

## Changes
- Created PageWrapper.tsx
  - Listens to route changes via useLocation
  - On route change: briefly sets opacity to 0 and translateY 
    to 8px, then transitions to fully visible
  - 0.25s ease transition for both opacity and transform
  - 20ms delay prevents flash on initial render
- Wrapped Routes in PageWrapper in App.tsx

## Testing
Tested locally — navigating between Home, Dashboard, Games, 
and other pages shows a smooth fade and slide-up animation.

## Issues Related
Closes #118