### PR TITLE
Consistent hover and focus states across all buttons (#121)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -114,3 +114,41 @@ body::before {
     grid-template-columns: 1fr !important;
   }
 }
+
+/* ===========================
+   Consistent hover/focus states
+   =========================== */
+
+/* Focus outline for keyboard accessibility */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid #7ecbff;
+  outline-offset: 2px;
+}
+
+/* Remove default outline when not keyboard navigating */
+button:focus:not(:focus-visible),
+a:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Subtle press effect on all buttons */
+button:active:not(:disabled) {
+  transform: scale(0.97);
+  transition: transform 0.1s ease;
+}
+
+/* Disabled state */
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed !important;
+}
+
+/* Link hover underline for text links */
+a.text-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}


### PR DESCRIPTION
## Summary
Adds consistent hover, focus, active, and disabled states 
across all interactive elements site-wide via global CSS.

## Changes
- Updated App.css with global button/input styles:
  - Focus outline: 2px solid #7ecbff with 2px offset for 
    keyboard accessibility (only shows on keyboard nav)
  - Active/pressed: scale(0.97) press effect on all buttons
  - Disabled: 0.5 opacity and not-allowed cursor
  - Text link hover: underline with 3px offset
  - Default focus outline removed for mouse users via 
    :focus:not(:focus-visible)

## Testing
Tested locally — tabbing through buttons shows blue focus 
ring, clicking buttons shows press effect, disabled buttons 
show reduced opacity.

## Issues Closed
Closes #121