### PR TITLE
Update page title per route (#114)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,13 @@ import SpectatorViewer from "./components/pages/SpectatorViewer";
 import ProfilePage from "./components/pages/ProfilePage";
 import { ToastProvider } from "./components/ToastProvider";
 import PageWrapper from "./components/PageWrapper";
+import { usePageTitle } from "./hooks/usePageTitle";
+
+// Component to update the page title on route change
+const PageTitleUpdater = () => {
+  usePageTitle();
+  return null;
+};
 
 
 // Protect all routes except public pages
@@ -64,6 +71,7 @@ function App() {
     <AuthProvider>
       <ToastProvider>
       <Router>
+        <PageTitleUpdater />
         <Navbar />
         <PageWrapper>
           <Routes>

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const routeTitles: Record<string, string> = {
+  "/": "Grumpy Gamer",
+  "/home": "Home | Grumpy Gamer",
+  "/games": "Game Selection | Grumpy Gamer",
+  "/dashboard": "Dashboard | Grumpy Gamer",
+  "/comparison": "Comparison | Grumpy Gamer",
+  "/human-vs-ai": "Human vs AI | Grumpy Gamer",
+  "/about": "About | Grumpy Gamer",
+  "/settings": "Settings | Grumpy Gamer",
+  "/profile": "Profile | Grumpy Gamer",
+  "/replays": "Replay History | Grumpy Gamer",
+  "/login": "Log In | Grumpy Gamer",
+  "/signup": "Sign Up | Grumpy Gamer",
+  "/faq": "FAQ | Grumpy Gamer",
+  "/contact": "Contact | Grumpy Gamer",
+};
+
+const gameNames: Record<string, string> = {
+  wordle: "Wordle",
+  sudoku: "Sudoku",
+  tictactoe: "Tic-Tac-Toe",
+  connectfour: "Connect Four",
+  chess: "Chess",
+  checkers: "Checkers",
+  rps: "Rock Paper Scissors",
+  minesweeper: "Minesweeper",
+  "2048": "2048",
+  hangman: "Hangman",
+  othello: "Othello",
+  memory: "Memory",
+};
+
+export function usePageTitle() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const path = location.pathname;
+
+    // Handle /play/:game routes
+    if (path.startsWith("/play/")) {
+      const game = path.split("/play/")[1];
+      const gameName = gameNames[game] || game;
+      document.title = `${gameName} | Grumpy Gamer`;
+      return;
+    }
+
+    // Handle /replay/:id routes
+    if (path.startsWith("/replay/")) {
+      document.title = "Replay Viewer | Grumpy Gamer";
+      return;
+    }
+
+    // Handle /watch/:id routes
+    if (path.startsWith("/watch/")) {
+      document.title = "Spectator Mode | Grumpy Gamer";
+      return;
+    }
+
+    // Known routes
+    const title = routeTitles[path] || "Grumpy Gamer";
+    document.title = title;
+  }, [location.pathname]);
+}


### PR DESCRIPTION
## Summary
Dynamically updates the browser tab title based on the current 
route, improving navigation clarity and SEO.

## Changes
- Created frontend/src/hooks/usePageTitle.ts
  - Custom hook that listens to route changes via useLocation
  - Maps known routes to descriptive titles
  - Handles dynamic routes:
    - /play/:game → "Wordle | Grumpy Gamer" etc.
    - /replay/:id → "Replay Viewer | Grumpy Gamer"
    - /watch/:id → "Spectator Mode | Grumpy Gamer"
  - Falls back to "Grumpy Gamer" for unknown routes
- Added PageTitleUpdater component to App.tsx
  - Renders null, just calls usePageTitle hook
  - Placed inside Router so it has access to location

## Page titles added
- / → Grumpy Gamer
- /home → Home | Grumpy Gamer
- /games → Game Selection | Grumpy Gamer
- /dashboard → Dashboard | Grumpy Gamer
- /comparison → Comparison | Grumpy Gamer
- /human-vs-ai → Human vs AI | Grumpy Gamer
- /profile → Profile | Grumpy Gamer
- /replays → Replay History | Grumpy Gamer
- /play/wordle → Wordle | Grumpy Gamer (etc.)

## Issues Closed
Closes #114