### PR TITLE
Memoize expensive React components and calculations (#134)

### DIFF
--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -7,7 +7,7 @@ interface SkeletonProps {
   style?: React.CSSProperties;
 }
 
-const Skeleton: React.FC<SkeletonProps> = ({
+const Skeleton: React.FC<SkeletonProps> = React.memo(({
   width = "100%",
   height = "1em",
   borderRadius = 8,
@@ -26,7 +26,7 @@ const Skeleton: React.FC<SkeletonProps> = ({
       }}
     />
   );
-};
+});
 
 // Inject keyframe animation once
 if (typeof document !== "undefined") {

--- a/frontend/src/components/pages/Dashboard.tsx
+++ b/frontend/src/components/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useDarkModeContext } from "../DarkModeProvider";
 import Skeleton from "../Skeleton";
 import { apiFetch } from "../../config/apiFetch";
@@ -51,11 +51,14 @@ const Dashboard: React.FC = () => {
     fetchData();
   }, []);
 
-  const totalGames = stats.reduce((s, g) => s + g.total, 0);
-  const totalWins = stats.reduce((s, g) => s + g.wins, 0);
-  const totalLosses = stats.reduce((s, g) => s + g.losses, 0);
-  const totalDraws = stats.reduce((s, g) => s + g.draws, 0);
-  const winRate = totalGames > 0 ? ((totalWins / totalGames) * 100).toFixed(1) : "0.0";
+  const { totalGames, totalWins, totalLosses, totalDraws, winRate } = useMemo(() => {
+    const totalGames = stats.reduce((s, g) => s + g.total, 0);
+    const totalWins = stats.reduce((s, g) => s + g.wins, 0);
+    const totalLosses = stats.reduce((s, g) => s + g.losses, 0);
+    const totalDraws = stats.reduce((s, g) => s + g.draws, 0);
+    const winRate = totalGames > 0 ? ((totalWins / totalGames) * 100).toFixed(1) : "0.0";
+    return { totalGames, totalWins, totalLosses, totalDraws, winRate };
+  }, [stats]);
 
   const cardStyle: React.CSSProperties = {
     background: cardBg, border: cardBorder, borderRadius: 16,

--- a/frontend/src/components/pages/HumanVsAI.tsx
+++ b/frontend/src/components/pages/HumanVsAI.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import AICoach from "../AICoach";
 import Skeleton from "../Skeleton";
@@ -54,8 +54,10 @@ const HumanVsAI: React.FC = () => {
     return () => { mounted = false; };
   }, []);
 
-  const totalWins = stats.reduce((s, g) => s + g.wins, 0);
-  const totalLosses = stats.reduce((s, g) => s + g.losses, 0);
+  const { totalWins, totalLosses } = useMemo(() => ({
+    totalWins: stats.reduce((s, g) => s + g.wins, 0),
+    totalLosses: stats.reduce((s, g) => s + g.losses, 0),
+  }), [stats]);
 
   const handleStartChallenge = () => {
     if (!selectedGame) return;


### PR DESCRIPTION
## Summary
Wraps expensive calculations in useMemo and memoizes the 
Skeleton component with React.memo to reduce unnecessary 
re-renders.

## Changes
- Updated Dashboard.tsx:
  - Wrapped totalGames, totalWins, totalLosses, totalDraws, 
    and winRate calculations in useMemo with stats as dependency
  - These reduce() calls now only recompute when stats data changes
- Updated HumanVsAI.tsx:
  - Wrapped totalWins and totalLosses in useMemo with stats 
    as dependency
- Updated Skeleton.tsx:
  - Wrapped component with React.memo so it only re-renders 
    when its props change

## Issues Closed
Closes #134