### PR TITLE
Add pagination to replays and stats history endpoints (#135)

### DIFF
--- a/backend/replays.py
+++ b/backend/replays.py
@@ -1,7 +1,7 @@
 """
 Replay API endpoints for recording and retrieving game moves.
 """
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from typing import Any
 
@@ -43,7 +43,11 @@ def record_move(
 
 
 @replays_router.get("/replays")
-def list_replays(token_email: str = Depends(verify_access_token)):
+def list_replays(
+    token_email: str = Depends(verify_access_token),
+    page: int = Query(1, ge=1),
+    limit: int = Query(20, ge=1, le=100)
+):
     """List the authenticated user's past game sessions that have recorded moves."""
     conn = get_db()
     cursor = conn.cursor()
@@ -61,13 +65,15 @@ def list_replays(token_email: str = Depends(verify_access_token)):
         GROUP BY gr.id, gr.game, gr.outcome, gr.played_at
         HAVING COUNT(gm.id) > 0
         ORDER BY gr.played_at DESC
-        LIMIT 50
+        LIMIT %s OFFSET %s
         """,
-        (token_email,)
+        (token_email, limit, (page - 1) * limit)
     )
     rows = cursor.fetchall()
     conn.close()
     return {
+        "page": page,
+        "limit": limit,
         "replays": [
             {
                 "session_id": r["session_id"],

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -2,7 +2,7 @@
 Analytics API endpoints for recording and summarising game results.
 """
 import time
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 try:
     from .auth import get_db
@@ -124,7 +124,10 @@ def get_activity(token_email: str = Depends(verify_access_token)):
 
 
 @stats_router.get("/stats/history")
-def get_history(token_email: str = Depends(verify_access_token)):
+def get_history(
+    token_email: str = Depends(verify_access_token),
+    days: int = Query(30, ge=1, le=365)
+):
     """Return win rate per day for the past 30 days (for performance over time chart)."""
     cache_key = f"{token_email}:history"
     cached = cache_get(cache_key)
@@ -141,15 +144,16 @@ def get_history(token_email: str = Depends(verify_access_token)):
             COUNT(*) AS total
         FROM game_results
         WHERE email = %s
-          AND played_at >= NOW() - INTERVAL '30 days'
+          AND played_at >= NOW() - INTERVAL '1 day' * %s
         GROUP BY DATE(played_at)
         ORDER BY date
         """,
-        (token_email,)
+        (token_email, days)
     )
     rows = cursor.fetchall()
     conn.close()
     result = {
+        "days": days,
         "history": [
             {
                 "date": str(r["date"]),


### PR DESCRIPTION
## Summary
Adds query parameter support to the replays and stats history 
endpoints so clients can request specific pages and date ranges 
instead of always getting a fixed set of results.

## Changes
- Updated GET /api/replays:
  - Added page query param (default: 1, min: 1)
  - Added limit query param (default: 20, min: 1, max: 100)
  - Response now includes page and limit fields
  - Uses LIMIT/OFFSET for efficient pagination
- Updated GET /api/stats/history:
  - Added days query param (default: 30, min: 1, max: 365)
  - Response now includes days field
  - Allows fetching 7, 30, 90, or 365 days of history

## Testing
Tested locally:
- GET /api/replays?page=1&limit=5 returns 1 result with 
  page and limit in response
- GET /api/stats/history?days=7 returns 1 day of history 
  with days field in response

## Issues Closed
Closes #135