### PR TITLE
Add rate limiting to login, signup, and AI coach endpoints (#148)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,5 +1,11 @@
 import os
 import asyncio
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+try:
+    from .limiter import limiter
+except ImportError:
+    from limiter import limiter
 import sentry_sdk
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
@@ -34,6 +40,8 @@ import os
 
 
 app = FastAPI()
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 ENV = os.environ.get("ENV", "development")
 if ENV == "production":

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -7,6 +7,11 @@ from psycopg2.extras import RealDictCursor
 from passlib.context import CryptContext
 from dotenv import load_dotenv
 try:
+    from limiter import limiter
+except ImportError:
+    from .limiter import limiter
+
+try:
     from .jwt_utils import verify_access_token, create_access_token
 except ImportError:
     from jwt_utils import verify_access_token, create_access_token
@@ -150,7 +155,8 @@ class UserLogin(BaseModel):
 
 
 @auth_router.post("/signup")
-def signup(user: UserSignup):
+@limiter.limit("5/minute")
+def signup(request: Request, user: UserSignup):
     conn = get_db()
     cursor = conn.cursor()
     hashed_pw = pwd_context.hash(user.password)
@@ -169,7 +175,8 @@ def signup(user: UserSignup):
 
 
 @auth_router.post("/login")
-def login(user: UserLogin):
+@limiter.limit("10/minute")
+def login(request: Request, user: UserLogin):
     conn = get_db()
     cursor = conn.cursor()
     cursor.execute(

--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,0 +1,4 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,4 @@ numpy>=1.24.0
 psycopg2-binary
 anthropic
 sentry-sdk[fastapi]
+slowapi

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -2,7 +2,11 @@
 Analytics API endpoints for recording and summarising game results.
 """
 import time
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
+try:
+    from .limiter import limiter
+except ImportError:
+    from limiter import limiter
 from pydantic import BaseModel
 try:
     from .auth import get_db
@@ -167,7 +171,8 @@ def get_history(
 
 
 @stats_router.post("/stats/coach")
-def get_coach_feedback(token_email: str = Depends(verify_access_token)):
+@limiter.limit("5/minute")
+def get_coach_feedback(request: Request, token_email: str = Depends(verify_access_token)):
     """Return AI-generated glows and grows feedback based on the user's game history."""
     import anthropic
     import json


### PR DESCRIPTION
## Summary
Adds rate limiting to protect the API from abuse, particularly 
the auth and AI coach endpoints.

## Changes
- Created backend/limiter.py
  - Shared Limiter instance using slowapi and client IP address
- Updated backend/api.py
  - Added slowapi exception handler for 429 responses
  - Imports limiter and registers RateLimitExceeded handler
- Updated backend/auth.py
  - POST /api/login — limited to 10 requests per minute
  - POST /api/signup — limited to 5 requests per minute
- Updated backend/stats.py
  - POST /api/stats/coach — limited to 5 requests per minute
    (AI endpoint is expensive so stricter limit)
- Added slowapi to requirements.txt

## Rate Limits
- Login: 10/minute per IP
- Signup: 5/minute per IP
- AI Coach: 5/minute per IP
- All other endpoints: unlimited

## Testing
13 backend tests still pass after changes.

## Issues Closed
Closes #148