### PR TITLE
Improve CORS configuration with ALLOWED_ORIGINS env var support (#150)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,3 +18,6 @@ OPENAI_MODEL=gpt-3.5-turbo
 
 # Environment
 ENV=production
+
+# CORS (optional - comma separated list of allowed origins)
+# ALLOWED_ORIGINS=https://grumpy-gamer.vercel.app,https://staging.grumpy-gamer.vercel.app

--- a/backend/api.py
+++ b/backend/api.py
@@ -44,7 +44,10 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 ENV = os.environ.get("ENV", "development")
-if ENV == "production":
+custom_origins = os.environ.get("ALLOWED_ORIGINS", "")
+if custom_origins:
+    origins = [o.strip() for o in custom_origins.split(",")]
+elif ENV == "production":
     origins = ["https://grumpy-gamer.vercel.app"]
 else:
     origins = ["*"]


### PR DESCRIPTION
## Summary
CORS was already environment-aware but this adds support for 
a custom ALLOWED_ORIGINS environment variable for more 
flexibility (e.g. staging environments).

## Changes
- Updated backend/api.py:
  - Added ALLOWED_ORIGINS environment variable support
  - If set, uses comma-separated list of allowed origins
  - Falls back to production URL if ENV=production
  - Falls back to wildcard * in development
- Updated backend/.env.example:
  - Added ALLOWED_ORIGINS documentation

## CORS Priority
1. ALLOWED_ORIGINS env var (if set) — use custom list
2. ENV=production — only allow grumpy-gamer.vercel.app
3. Development — allow all origins (*)

## Example
To allow staging + production:
ALLOWED_ORIGINS=https://grumpy-gamer.vercel.app,https://staging.grumpy-gamer.vercel.app

## Issues Closed
Closes #150