### PR TITLE
Add Swagger API documentation with tags and app description (#163)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -39,7 +39,29 @@ from fastapi.middleware.cors import CORSMiddleware
 import os
 
 
-app = FastAPI()
+app = FastAPI(
+    title="Grumpy Gamer API",
+    description="""
+## 🎮 Grumpy Gamer API
+
+A full-stack gaming platform where humans challenge AI opponents across 12 classic games.
+
+### Features
+- **Authentication** — JWT-based signup/login
+- **Game Stats** — Track wins, losses, draws per game
+- **Replays** — Record and replay game moves
+- **AI Coach** — Claude-powered personalized feedback
+- **Chatbot** — Interactive game assistant
+""",
+    version="1.0.0",
+    contact={
+        "name": "Grumpy Gamer",
+        "url": "https://grumpy-gamer.vercel.app",
+    },
+    license_info={
+        "name": "MIT",
+    },
+)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -18,7 +18,7 @@ except ImportError:
 
 load_dotenv()
 
-auth_router = APIRouter()
+auth_router = APIRouter(tags=["Authentication"])
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/backend/replays.py
+++ b/backend/replays.py
@@ -12,7 +12,7 @@ except ImportError:
     from auth import get_db
     from jwt_utils import verify_access_token
 
-replays_router = APIRouter()
+replays_router = APIRouter(tags=["Replays"])
 
 
 class MoveRecord(BaseModel):

--- a/backend/stats.py
+++ b/backend/stats.py
@@ -15,7 +15,7 @@ except ImportError:
     from auth import get_db
     from jwt_utils import verify_access_token
 
-stats_router = APIRouter()
+stats_router = APIRouter(tags=["Stats"])
 
 # Simple in-memory cache: { cache_key: { "data": ..., "expires_at": float } }
 _cache: dict = {}


### PR DESCRIPTION
## Summary
Improves the auto-generated FastAPI Swagger docs at /docs 
with a rich app description and organized endpoint tags.

## Changes
- Updated api.py:
  - Added full app metadata to FastAPI constructor:
    - Title: "Grumpy Gamer API"
    - Description with features overview in Markdown
    - Version: 1.0.0
    - Contact and license info
- Updated auth.py:
  - Added tags=["Authentication"] to auth_router
- Updated stats.py:
  - Added tags=["Stats"] to stats_router
- Updated replays.py:
  - Added tags=["Replays"] to replays_router

## Result
Visiting https://grumpy-gamer.onrender.com/docs now shows:
- Organized endpoint groups by tag
- App description with feature overview
- Version and contact info

## Issues Closed
Closes #163