### PR TITLE
Fix remaining TypeScript any types (#168)

### DIFF
--- a/frontend/src/components/Chatbot.tsx
+++ b/frontend/src/components/Chatbot.tsx
@@ -7,7 +7,7 @@ import './Chatbot.css'; // Create this CSS file for styling
 // TypeScript declaration for Google Analytics gtag
 declare global {
   interface Window {
-    gtag?: (...args: any[]) => void;
+    gtag?: (...args: unknown[]) => void;
   }
 }
 
@@ -132,7 +132,7 @@ const Chatbot = () => {
         botMsg = { from: 'bot', ...data.response };
       }
       setMessages(prev => [...prev, botMsg]);
-    } catch (err: any) {
+    } catch (err: unknown) {
       setError('Sorry, there was a problem connecting to the chatbot. Please try again.');
       setMessages(prev => [...prev, { from: 'bot', text: 'Sorry, I could not process your request.' }]);
     } finally {


### PR DESCRIPTION
## Summary
TypeScript strict mode was already enabled in tsconfig.json. 
This PR fixes the remaining explicit any types found in the 
codebase.

## Changes
- Updated frontend/src/components/Chatbot.tsx:
  - Changed gtag?: (...args: any[]) => void to 
    (...args: unknown[]) => void
  - Changed catch (err: any) to catch (err: unknown)

## Notes
- strict: true was already set in tsconfig.json
- npx tsc --noEmit passes with no errors after these changes
- Game2048.tsx had "anyMoved" variable name which is not 
  an any type — it was a false positive in the grep

## Issues Closed
Closes #168