### PR TITLE
Add presentation slide deck link to README and project summary (#182)

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -158,6 +158,6 @@ Demo video, slide deck, final metrics, and project handover.
 
 *Built with too much caffeine, too many late nights, and a genuine love for making AI look bad at board games.*
 
-**[Play Now →](https://grumpy-gamer.vercel.app)**
+**[Play Now →](https://grumpy-gamer.vercel.app) · [Slide Deck →](https://docs.google.com/presentation/d/1nBV9nYjTpSZuZ35boGEnFM7Tr09Mkt9f74vHxj8Gt3A/edit?usp=sharing)**
 
 </div>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
 
-**[Live Demo](https://grumpy-gamer.vercel.app) · [API Docs](https://grumpy-gamer.onrender.com/docs) · [Report Bug](https://github.com/jellyfishing2346/grumpy-gamer/issues)**
+**[Live Demo](https://grumpy-gamer.vercel.app) · [API Docs](https://grumpy-gamer.onrender.com/docs) · [Slide Deck](https://docs.google.com/presentation/d/1nBV9nYjTpSZuZ35boGEnFM7Tr09Mkt9f74vHxj8Gt3A/edit?usp=sharing) · [Report Bug](https://github.com/jellyfishing2346/grumpy-gamer/issues)**
 
 </div>
 


### PR DESCRIPTION
## Summary
Links the Google Slides presentation deck to the README 
and project summary document so it's easily accessible 
from the repository.

## Changes
- Updated README.md header links to include Slide Deck
- Updated PROJECT_SUMMARY.md footer to include Slide Deck link

## Slide Deck
https://docs.google.com/presentation/d/1nBV9nYjTpSZuZ35boGEnFM7Tr09Mkt9f74vHxj8Gt3A/edit?usp=sharing

## Issues Closed
Closes #182