### PR TITLE
Add AI training metrics dashboard at /ai-metrics (#190)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -33,8 +33,10 @@ except ImportError:
     from stats import stats_router
 try:
     from .replays import replays_router
+    from .rl_metrics import rl_router
 except ImportError:
     from replays import replays_router
+    from rl_metrics import rl_router
 from fastapi.middleware.cors import CORSMiddleware
 import os
 
@@ -94,6 +96,7 @@ app.include_router(auth_router, prefix="/api")
 app.include_router(chatbot_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(replays_router, prefix="/api")
+app.include_router(rl_router, prefix="/api")
 
 
 async def keep_alive_ping():

--- a/backend/rl_metrics.py
+++ b/backend/rl_metrics.py
@@ -4,7 +4,6 @@ Provides endpoints for viewing trained model performance stats.
 """
 from fastapi import APIRouter
 import os
-import zipfile
 
 rl_router = APIRouter()
 

--- a/backend/rl_metrics.py
+++ b/backend/rl_metrics.py
@@ -1,0 +1,120 @@
+"""
+RL Training Metrics API
+Provides endpoints for viewing trained model performance stats.
+"""
+from fastapi import APIRouter
+import os
+import zipfile
+
+rl_router = APIRouter()
+
+MODELS_DIR = os.path.join(os.path.dirname(__file__), "rl", "models")
+
+TRAINING_RESULTS = {
+    "tictactoe": {
+        "game": "Tic-Tac-Toe",
+        "algorithm": "PPO",
+        "timesteps": 100000,
+        "win_rate_random": 83,
+        "loss_rate_random": 17,
+        "draw_rate_random": 0,
+        "invalid_moves": 0,
+        "training_time_seconds": 38,
+        "model_file": "tictactoe_best.zip",
+        "status": "trained",
+    },
+    "connectfour": {
+        "game": "Connect Four",
+        "algorithm": "PPO",
+        "timesteps": 100000,
+        "win_rate_random": 96,
+        "loss_rate_random": 4,
+        "draw_rate_random": 0,
+        "invalid_moves": 0,
+        "training_time_seconds": 64,
+        "model_file": "connectfour_best.zip",
+        "status": "trained",
+    },
+    "checkers": {
+        "game": "Checkers",
+        "algorithm": "PPO",
+        "timesteps": 300000,
+        "win_rate_random": 50,
+        "loss_rate_random": 50,
+        "draw_rate_random": 0,
+        "invalid_moves": 0,
+        "training_time_seconds": 480,
+        "model_file": "checkers_best.zip",
+        "status": "trained",
+    },
+    "othello": {
+        "game": "Othello",
+        "algorithm": "PPO",
+        "timesteps": 200000,
+        "win_rate_random": 20,
+        "loss_rate_random": 80,
+        "draw_rate_random": 0,
+        "invalid_moves": 0,
+        "training_time_seconds": 780,
+        "model_file": "othello_best.zip",
+        "status": "trained",
+    },
+    "chess": {
+        "game": "Chess",
+        "algorithm": "PPO",
+        "timesteps": 0,
+        "win_rate_random": None,
+        "loss_rate_random": None,
+        "draw_rate_random": None,
+        "invalid_moves": None,
+        "training_time_seconds": 0,
+        "model_file": "chess_best.zip",
+        "status": "needs_gpu",
+    },
+    "minesweeper": {
+        "game": "Minesweeper",
+        "algorithm": "DQN",
+        "timesteps": 100000,
+        "win_rate_random": None,
+        "loss_rate_random": None,
+        "draw_rate_random": None,
+        "invalid_moves": None,
+        "training_time_seconds": 0,
+        "model_file": "minesweeper_best.zip",
+        "status": "trained",
+    },
+}
+
+
+@rl_router.get("/rl/metrics")
+def get_rl_metrics():
+    """Return training metrics for all RL models."""
+    results = []
+    for game_id, data in TRAINING_RESULTS.items():
+        model_path = os.path.join(MODELS_DIR, data["model_file"])
+        model_size_mb = None
+        if os.path.exists(model_path):
+            model_size_mb = round(os.path.getsize(model_path) / (1024 * 1024), 1)
+        results.append({
+            "id": game_id,
+            **data,
+            "model_size_mb": model_size_mb,
+            "model_exists": os.path.exists(model_path),
+        })
+    return {"models": results}
+
+
+@rl_router.get("/rl/metrics/{game_id}")
+def get_game_metrics(game_id: str):
+    """Return training metrics for a specific game."""
+    if game_id not in TRAINING_RESULTS:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=404, detail=f"Game {game_id} not found")
+    data = TRAINING_RESULTS[game_id]
+    model_path = os.path.join(MODELS_DIR, data["model_file"])
+    return {
+        "id": game_id,
+        **data,
+        "model_size_mb": round(os.path.getsize(model_path) / (1024 * 1024), 1) if os.path.exists(model_path) else None,
+        "model_exists": os.path.exists(model_path),
+    }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ const Game2048 = lazy(() => import("./components/games/Game2048"));
 const HangmanGame = lazy(() => import("./components/games/HangmanGame"));
 const OthelloGame = lazy(() => import("./components/games/OthelloGame"));
 const MemoryGame = lazy(() => import("./components/games/MemoryGame"));
+const AIMetrics = lazy(() => import("./components/pages/AIMetrics"));
 
 
 // Component to update the page title on route change
@@ -103,6 +104,7 @@ function App() {
                     <Route path="comparison" element={<Comparison />} />
                     <Route path="human-vs-ai" element={<HumanVsAI />} />
                     <Route path="about" element={<About />} />
+              <Route path="ai-metrics" element={<AIMetrics />} />
                     <Route path="settings" element={<Settings />} />
                     <Route path="play/wordle" element={<WordleGame />} />
                     <Route path="play/sudoku" element={<SudokuGame />} />

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -82,6 +82,7 @@ const Navbar = () => {
     { to: "/replays", label: "Replays" },
     { to: "/profile", label: "Profile" },
     { to: "/about", label: "About" },
+    { to: "/ai-metrics", label: "🤖 AI Metrics" },
     { to: "/settings", label: "Settings" },
   ];
 

--- a/frontend/src/components/pages/AIMetrics.tsx
+++ b/frontend/src/components/pages/AIMetrics.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState } from "react";
+import API_URL from "../../config/api";
+
+interface ModelMetrics {
+  id: string;
+  game: string;
+  algorithm: string;
+  timesteps: number;
+  win_rate_random: number | null;
+  loss_rate_random: number | null;
+  draw_rate_random: number | null;
+  training_time_seconds: number;
+  model_size_mb: number | null;
+  model_exists: boolean;
+  status: string;
+}
+
+const statusColor: Record<string, string> = {
+  trained: "#4ade80",
+  needs_gpu: "#fbbf24",
+  in_progress: "#7ecbff",
+};
+
+const statusLabel: Record<string, string> = {
+  trained: "✅ Trained",
+  needs_gpu: "⚠️ Needs GPU",
+  in_progress: "🔄 Training",
+};
+
+const AIMetrics: React.FC = () => {
+  const [models, setModels] = useState<ModelMetrics[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/rl/metrics`)
+      .then((r) => r.json())
+      .then((data) => {
+        setModels(data.models || []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError("Failed to load metrics");
+        setLoading(false);
+      });
+  }, []);
+
+  const containerStyle: React.CSSProperties = {
+    minHeight: "100vh",
+    background: "#0f1117",
+    color: "#e8f4f8",
+    fontFamily: "'DM Sans', 'Inter', sans-serif",
+    padding: "2rem",
+  };
+
+  const headerStyle: React.CSSProperties = {
+    textAlign: "center",
+    marginBottom: "2rem",
+  };
+
+  const cardStyle: React.CSSProperties = {
+    background: "rgba(255,255,255,0.04)",
+    border: "1px solid rgba(126,203,255,0.1)",
+    borderRadius: 16,
+    padding: "1.5rem",
+    marginBottom: "1rem",
+  };
+
+  const barContainerStyle: React.CSSProperties = {
+    background: "rgba(255,255,255,0.06)",
+    borderRadius: 8,
+    height: 12,
+    width: "100%",
+    overflow: "hidden",
+    marginTop: "0.5rem",
+  };
+
+  if (loading) {
+    return (
+      <div style={{ ...containerStyle, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <p style={{ color: "rgba(255,255,255,0.5)" }}>Loading metrics...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ ...containerStyle, display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <p style={{ color: "#ff7e67" }}>{error}</p>
+      </div>
+    );
+  }
+
+  const trained = models.filter((m) => m.status === "trained");
+  const totalTimesteps = models.reduce((s, m) => s + m.timesteps, 0);
+  const avgWinRate = trained.filter((m) => m.win_rate_random !== null)
+    .reduce((s, m) => s + (m.win_rate_random || 0), 0) /
+    (trained.filter((m) => m.win_rate_random !== null).length || 1);
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle}>
+        <h1 style={{ fontSize: "2rem", fontWeight: 800, color: "#7ecbff", marginBottom: "0.5rem" }}>
+          🤖 AI Training Metrics
+        </h1>
+        <p style={{ color: "rgba(255,255,255,0.5)", fontSize: "1rem" }}>
+          Reinforcement Learning model performance across all games
+        </p>
+      </div>
+
+      {/* Summary Cards */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: "1rem", marginBottom: "2rem" }}>
+        {[
+          { label: "Models Trained", value: trained.length, icon: "🎯" },
+          { label: "Total Timesteps", value: `${(totalTimesteps / 1000).toFixed(0)}k`, icon: "⚡" },
+          { label: "Avg Win Rate", value: `${avgWinRate.toFixed(0)}%`, icon: "🏆" },
+          { label: "Games Covered", value: models.length, icon: "🎮" },
+        ].map((stat) => (
+          <div key={stat.label} style={{ ...cardStyle, textAlign: "center" }}>
+            <div style={{ fontSize: "1.8rem" }}>{stat.icon}</div>
+            <div style={{ fontSize: "1.5rem", fontWeight: 800, color: "#7ecbff" }}>{stat.value}</div>
+            <div style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.5)" }}>{stat.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Model Cards */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(320px, 1fr))", gap: "1rem" }}>
+        {models.map((model) => (
+          <div key={model.id} style={cardStyle}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1rem" }}>
+              <h3 style={{ margin: 0, fontSize: "1.1rem", fontWeight: 700 }}>{model.game}</h3>
+              <span style={{
+                fontSize: "0.75rem",
+                padding: "0.25em 0.75em",
+                borderRadius: 50,
+                background: `${statusColor[model.status]}22`,
+                color: statusColor[model.status],
+                border: `1px solid ${statusColor[model.status]}44`,
+              }}>
+                {statusLabel[model.status] || model.status}
+              </span>
+            </div>
+
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.5rem", marginBottom: "1rem", fontSize: "0.85rem" }}>
+              <div style={{ color: "rgba(255,255,255,0.5)" }}>Algorithm</div>
+              <div style={{ fontWeight: 600 }}>{model.algorithm}</div>
+              <div style={{ color: "rgba(255,255,255,0.5)" }}>Timesteps</div>
+              <div style={{ fontWeight: 600 }}>{model.timesteps > 0 ? `${(model.timesteps / 1000).toFixed(0)}k` : "—"}</div>
+              <div style={{ color: "rgba(255,255,255,0.5)" }}>Training Time</div>
+              <div style={{ fontWeight: 600 }}>{model.training_time_seconds > 0 ? `${Math.round(model.training_time_seconds / 60)}m` : "—"}</div>
+              <div style={{ color: "rgba(255,255,255,0.5)" }}>Model Size</div>
+              <div style={{ fontWeight: 600 }}>{model.model_size_mb ? `${model.model_size_mb} MB` : "—"}</div>
+            </div>
+
+            {model.win_rate_random !== null && (
+              <div>
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.85rem", marginBottom: "0.25rem" }}>
+                  <span style={{ color: "rgba(255,255,255,0.5)" }}>Win Rate vs Random</span>
+                  <span style={{ fontWeight: 700, color: "#4ade80" }}>{model.win_rate_random}%</span>
+                </div>
+                <div style={barContainerStyle}>
+                  <div style={{
+                    height: "100%",
+                    width: `${model.win_rate_random}%`,
+                    background: "linear-gradient(90deg, #4ade80, #22c55e)",
+                    borderRadius: 8,
+                    transition: "width 1s ease",
+                  }} />
+                </div>
+
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: "0.85rem", marginTop: "0.75rem", marginBottom: "0.25rem" }}>
+                  <span style={{ color: "rgba(255,255,255,0.5)" }}>Loss Rate</span>
+                  <span style={{ fontWeight: 700, color: "#f87171" }}>{model.loss_rate_random}%</span>
+                </div>
+                <div style={barContainerStyle}>
+                  <div style={{
+                    height: "100%",
+                    width: `${model.loss_rate_random || 0}%`,
+                    background: "linear-gradient(90deg, #f87171, #ef4444)",
+                    borderRadius: 8,
+                  }} />
+                </div>
+              </div>
+            )}
+
+            {model.status === "needs_gpu" && (
+              <p style={{ color: "rgba(255,255,255,0.4)", fontSize: "0.82rem", marginTop: "0.5rem" }}>
+                Requires GPU training (millions of timesteps)
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AIMetrics;


### PR DESCRIPTION
## Summary
Adds a new /ai-metrics page showing training results and 
performance stats for all RL models, and a backend API 
endpoint to serve the metrics.

## Changes
- Created backend/rl_metrics.py:
  - GET /api/rl/metrics — returns all model metrics
  - GET /api/rl/metrics/{game_id} — returns single game metrics
  - Includes win rate, timesteps, training time, model size
  - Registered in api.py with /api prefix
- Created frontend/src/components/pages/AIMetrics.tsx:
  - Summary cards: models trained, total timesteps, 
    avg win rate, games covered
  - Per-game cards showing algorithm, timesteps, 
    training time, model size
  - Win rate and loss rate progress bars
  - Status badges: Trained, Needs GPU, In Progress
  - Lazy loaded via React.lazy()
- Updated Navbar.tsx:
  - Added 🤖 AI Metrics link
- Updated App.tsx:
  - Added /ai-metrics route

## Models Shown
| Game | Win Rate vs Random | Status |
|------|--------------------|--------|
| TicTacToe | 83% | ✅ Trained |
| Connect Four | 96% | ✅ Trained |
| Checkers | 50% | ✅ Trained |
| Othello | 20% | ✅ Trained |
| Chess | — | ⚠️ Needs GPU |
| Minesweeper | — | ✅ Trained |

## Issues Closed
Closes #190